### PR TITLE
fix: Job annehmen buttons disabled when it's not the players turn

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/DistributionPackages/eventstore-laraveladapter" vcs="Git" />

--- a/app/app/Livewire/Traits/HasJobOffer.php
+++ b/app/app/Livewire/Traits/HasJobOffer.php
@@ -36,8 +36,9 @@ trait HasJobOffer
         $this->jobOfferIsVisible = false;
     }
 
-    public function canAcceptJobOffer(CardId $cardId): AktionValidationResult
+    public function canAcceptJobOffer(string $cardIdString): AktionValidationResult
     {
+        $cardId = new CardId($cardIdString);
         $aktion = new AcceptJobOfferAktion($cardId);
         return $aktion->validate($this->myself, $this->gameEvents);
     }
@@ -49,7 +50,7 @@ trait HasJobOffer
     public function applyForJob(string $cardIdString): void
     {
         $cardId = new CardId($cardIdString);
-        $validationResult = self::canAcceptJobOffer($cardId);
+        $validationResult = self::canAcceptJobOffer($cardIdString);
         if (!$validationResult->canExecute) {
             $this->showNotification(
                 $validationResult->reason,

--- a/app/resources/views/components/gameboard/job-offers-modal.blade.php
+++ b/app/resources/views/components/gameboard/job-offers-modal.blade.php
@@ -1,5 +1,4 @@
 @extends ('components.modal.modal', ['closeModal' => "closeJobOffer()", 'type' => "borderless"])
-@use('Domain\CoreGameLogic\Feature\Spielzug\State\AktionsCalculator')
 @use('Domain\CoreGameLogic\Feature\Spielzug\State\CurrentPlayerAccessor')
 
 @props([
@@ -27,7 +26,7 @@
 @section('content')
     <div class="job-offers">
         @foreach($jobOffers as $jobOffer)
-            <div @class(["card", "card--disabled" => !AktionsCalculator::forStream($gameEvents)->canPlayerAffordJobCard($playerId, $jobOffer)])>
+            <div @class(["card", "card--disabled" => !$this->canAcceptJobOffer($jobOffer->getId()->value)->canExecute])>
                 <h4 class="card__title">{{ $jobOffer->getTitle() }}</h4>
                 <div class="card__content">
                     <div class="resource-change">
@@ -38,7 +37,7 @@
                         @class([
                             "button",
                             "button--type-primary",
-                            "button--disabled" => !AktionsCalculator::forStream($gameEvents)->canPlayerAffordJobCard($playerId, $jobOffer) || !CurrentPlayerAccessor::forStream($gameEvents)->equals($playerId),
+                            "button--disabled" => !$this->canAcceptJobOffer($jobOffer->getId()->value)->canExecute,
                             $this->getPlayerColorClass()
                         ])
                         wire:click="applyForJob('{{ $jobOffer->getId()->value }}')"

--- a/app/resources/views/components/gameboard/job-offers-modal.blade.php
+++ b/app/resources/views/components/gameboard/job-offers-modal.blade.php
@@ -1,5 +1,6 @@
 @extends ('components.modal.modal', ['closeModal' => "closeJobOffer()", 'type' => "borderless"])
 @use('Domain\CoreGameLogic\Feature\Spielzug\State\AktionsCalculator')
+@use('Domain\CoreGameLogic\Feature\Spielzug\State\CurrentPlayerAccessor')
 
 @props([
     'jobOffers' => [],
@@ -37,7 +38,7 @@
                         @class([
                             "button",
                             "button--type-primary",
-                            "button--disabled" => !AktionsCalculator::forStream($gameEvents)->canPlayerAffordJobCard($playerId, $jobOffer),
+                            "button--disabled" => !AktionsCalculator::forStream($gameEvents)->canPlayerAffordJobCard($playerId, $jobOffer) || !CurrentPlayerAccessor::forStream($gameEvents)->equals($playerId),
                             $this->getPlayerColorClass()
                         ])
                         wire:click="applyForJob('{{ $jobOffer->getId()->value }}')"


### PR DESCRIPTION
The Buttons are now disabled when the player has the resources to accept the job but it's not the players turn.

Closes: #314 