### PR TITLE
fix: success message for moneysheet input

### DIFF
--- a/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-living-costs.blade.php
+++ b/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-living-costs.blade.php
@@ -40,7 +40,7 @@
     <div class="tabs__lower-content taxes__actions">
         @error('moneySheetLebenshaltungskostenForm.lebenshaltungskosten') <span class="form__error">{{ $message }}</span> @enderror
         @if ($this->moneySheetLebenshaltungskostenForm->isLebenshaltungskostenInputDisabled)
-            <span class="text--success"><i class="icon-info" aria-hidden="true"></i> Du hast deine Lebenshaltungskosten erfolgreich eingetragen. Das Formular ist so lange deaktiviert bis sich an deinem Gehalt etwas ändert.</span>
+            <span class="text--success"><i class="icon-info" aria-hidden="true"></i> Deine Lebenshaltungskosten sind erfolgreich eingetragen. Das Formular ist so lange deaktiviert bis sich an deinem Gehalt etwas ändert.</span>
         @endif
         <x-form.submit :disabled="$this->moneySheetLebenshaltungskostenForm->isLebenshaltungskostenInputDisabled">Änderungen Speichern</x-form.submit>
     </div>

--- a/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-taxes.blade.php
+++ b/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-taxes.blade.php
@@ -28,7 +28,7 @@
         @error('moneySheetSteuernUndAbgabenForm.steuernUndAbgaben') <span class="form__error">{{ $message }}</span> @enderror
         @if ($this->moneySheetSteuernUndAbgabenForm->isSteuernUndAbgabenInputDisabled)
             <span class="text--success">
-                <i class="icon-info" aria-hidden="true"></i> Du hast deine Steuern und Abgaben erfolgreich eingetragen. Das Formular ist so lange deaktiviert bis sich an deinem Gehalt etwas ändert.
+                <i class="icon-info" aria-hidden="true"></i> Deine Steuern und Abgaben sind erfolgreich eingetragen. Das Formular ist so lange deaktiviert bis sich an deinem Gehalt etwas ändert.
             </span>
         @endif
         <x-form.submit :disabled="$this->moneySheetSteuernUndAbgabenForm->isSteuernUndAbgabenInputDisabled">Änderungen Speichern</x-form.submit>


### PR DESCRIPTION
Success message fits 'correct input' and 'input was corrected'.

Closes: #334