### PR TITLE
fix: display active Zeitsteinmodifier in Jobtab (Moneysheet)

### DIFF
--- a/app/app/View/Components/MoneySheet/Expenses/MoneySheetLivingCosts.php
+++ b/app/app/View/Components/MoneySheet/Expenses/MoneySheetLivingCosts.php
@@ -35,7 +35,7 @@ class MoneySheetLivingCosts extends Component
         $modifierDescriptions = array_map(
             fn(Modifier $modifier) => $modifier->description,
             $modifiersForPlayer
-                ->getModifiersForHook(HookEnum::LEBENSHALTUNGSKOSTEN_MULTIPLIER)
+                ->getActiveModifiersForHook(HookEnum::LEBENSHALTUNGSKOSTEN_MULTIPLIER, $this->gameEvents)
                 ->getModifiers()
         );
         $livingCostMultiplier = MoneySheetState::getMultiplierForLebenshaltungskostenForPlayer($this->gameEvents, $this->playerId);

--- a/app/app/View/Components/MoneySheet/Income/MoneySheetSalary.php
+++ b/app/app/View/Components/MoneySheet/Income/MoneySheetSalary.php
@@ -31,10 +31,10 @@ class MoneySheetSalary extends Component
     {
         $modifiersForPlayer = ModifierCalculator::forStream($this->gameEvents)->forPlayer($this->playerId);
 
-        $zeitsteinModifiers = $modifiersForPlayer->getModifiersForHook(HookEnum::ZEITSTEINE);
+        $zeitsteinModifiers = $modifiersForPlayer->getActiveModifiersForHook(HookEnum::ZEITSTEINE, $this->gameEvents);
         $gehaltModifiers = [
-            ...$modifiersForPlayer->getModifiersForHook(HookEnum::GEHALT),
-            ...$modifiersForPlayer->getModifiersForHook(HookEnum::BERUFSUNFAEHIGKEIT_GEHALT)
+            ...$modifiersForPlayer->getActiveModifiersForHook(HookEnum::GEHALT, $this->gameEvents),
+            ...$modifiersForPlayer->getActiveModifiersForHook(HookEnum::BERUFSUNFAEHIGKEIT_GEHALT, $this->gameEvents)
         ];
 
         return view('components.gameboard.moneySheet.income.money-sheet-salary', [

--- a/app/src/CoreGameLogic/Feature/Spielzug/Modifier/ModifierCollection.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/Modifier/ModifierCollection.php
@@ -80,8 +80,8 @@ readonly class ModifierCollection implements \IteratorAggregate
         return array_reduce($this->modifiers, $callback, $initial);
     }
 
-    public function getModifiersForHook(HookEnum $hookEnum): self
+    public function getActiveModifiersForHook(HookEnum $hookEnum, GameEvents $gameEvents): self
     {
-        return $this->filter(fn (Modifier $modifier) => $modifier->canModify($hookEnum));
+        return $this->filter(fn (Modifier $modifier) => $modifier->canModify($hookEnum) && $modifier->isActive($gameEvents));
     }
 }


### PR DESCRIPTION
Displays just the current active Zeitsteinmodifier if the player has a job. Before it rendered all past jobs (wether they are active or not).

Closes: #299 