### PR TITLE
fix: merging of modals

### DIFF
--- a/app/resources/views/components/gameboard/its-your-turn-notification.blade.php
+++ b/app/resources/views/components/gameboard/its-your-turn-notification.blade.php
@@ -1,14 +1,14 @@
-@extends ('components.modal.modal', ['type' => "mandatory"])
+@extends ('components.modal.mandatory-modal')
 
-@section('icon')
+@section('icon_mandatory')
     <i class="icon-info" aria-hidden="true"></i>
 @endsection
 
-@section('content')
+@section('content_mandatory')
     <h3>Du bist am Zug!</h3>
 @endsection
 
-@section('footer')
+@section('footer_mandatory')
     <button type="button"
             @class([
                 "button",

--- a/app/resources/views/components/gameboard/sell-stocks-modal.blade.php
+++ b/app/resources/views/components/gameboard/sell-stocks-modal.blade.php
@@ -7,17 +7,17 @@
     'game-events' => null,
 ])
 
-@section('title')
+@section('title_mandatory')
     <span>
         Verkauf - {{ $this->sellStocksForm->stockType->toPrettyString() }} Aktie <i class="icon-aktien" aria-hidden="true"></i>
     </span>
 @endsection
 
-@section('icon')
+@section('icon_mandatory')
     <i class="icon-ereignis" aria-hidden="true"></i>
 @endsection
 
-@section('content')
+@section('content_mandatory')
     <h4>Ein anderer Spieler hat Aktien vom Typ {{ $this->sellStocksForm->stockType->toPrettyString() }} gekauft!</h4>
     @if ($this->sellStocksForm->amountOwned > 0)
         <p>
@@ -47,7 +47,7 @@
     @endif
 @endsection
 
-@section('footer')
+@section('footer_mandatory')
     <button type="button"
             @class([
                 "button",

--- a/app/resources/views/components/modal/mandatory-modal.blade.php
+++ b/app/resources/views/components/modal/mandatory-modal.blade.php
@@ -6,25 +6,25 @@
 >
     <div class="modal__backdrop"></div>
     <div class="modal__content">
-        @hasSection('icon')
+        @hasSection('icon_mandatory')
             <div class="modal__icon">
-                @yield('icon')
+                @yield('icon_mandatory')
             </div>
         @endif
 
-        @hasSection('title')
+        @hasSection('title_mandatory')
             <div class="modal__header">
-                @yield('title')
+                @yield('title_mandatory')
             </div>
         @endif
 
         <div class="modal__body">
-            @yield('content')
+            @yield('content_mandatory')
         </div>
 
-        @hasSection('footer')
+        @hasSection('footer_mandatory')
             <footer class="modal__actions">
-                @yield('footer')
+                @yield('footer_mandatory')
             </footer>
         @endif
     </div>


### PR DESCRIPTION
When the player has a modal open (e.g. job offers, moneysheet) and another modal gets triggered (e.g. sell stocks, it's your turn), the modals merged into each other as one. 

This happened due to the same section names in the two blade layouts (modal and mandatory-modal) -> fixed with renaming 
or due to two modals triggered after another extending the same layout -> fixed with 'it's your turn'-modal changed to mandatory-modal layout

Ref: #319 