### PR TITLE
fix: only update gameEvents when necessary

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -463,7 +463,12 @@
     <PhpStan_settings>
       <PhpStanConfiguration tool_path="$PROJECT_DIR$/app/vendor/bin/phpstan" />
       <phpstan_by_interpreter interpreter_id="514a332a-0a67-412b-89f6-5bb8cebec009" tool_path="$PROJECT_DIR$/app/vendor/bin/phpstan" timeout="60000" />
+      <phpstan_by_interpreter asDefaultInterpreter="true" interpreter_id="8edbe9dd-3630-4d84-8e5c-636cd7e749fb" tool_path="/app/vendor/bin/phpstan" timeout="60000" />
     </PhpStan_settings>
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="config" value="$PROJECT_DIR$/app/phpstan.neon" />
+    <option name="fullProject" value="true" />
   </component>
   <component name="PhpUnit">
     <phpunit_settings>

--- a/app/app/Livewire/GameUi.php
+++ b/app/app/Livewire/GameUi.php
@@ -20,6 +20,7 @@ use App\Livewire\Traits\HasPreGamePhase;
 use App\Livewire\Traits\HasMoneySheet;
 use App\Livewire\Traits\HasMinijob;
 use App\Livewire\Traits\HasQuitJob;
+use Domain\CoreGameLogic\CommandHandler\CommandInterface;
 use Domain\CoreGameLogic\DrivingPorts\ForCoreGameLogic;
 use Domain\CoreGameLogic\EventStore\GameEvents;
 use Domain\CoreGameLogic\Feature\Initialization\State\PreGameState;
@@ -28,7 +29,6 @@ use Domain\CoreGameLogic\Feature\Spielzug\State\CurrentPlayerAccessor;
 use Domain\CoreGameLogic\Feature\Spielzug\State\PlayerState;
 use Domain\CoreGameLogic\GameId;
 use Domain\CoreGameLogic\PlayerId;
-use Domain\Definitions\Lebensziel\LebenszielFinder;
 use Illuminate\Events\Dispatcher;
 use Illuminate\View\View;
 use Livewire\Component;
@@ -97,7 +97,17 @@ class GameUi extends Component
      */
     public function getGameEvents(): GameEvents
     {
-        return $this->coreGameLogic->getGameEvents($this->gameId);
+        return $this->gameEvents;
+    }
+
+    /**
+     * Always use this method to execute commands in the frontend, because it will
+     * also update the local gameEvents.
+     */
+    public function handleCommand(CommandInterface $command): void
+    {
+        $this->coreGameLogic->handle($this->gameId, $command);
+        $this->gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
     }
 
     /**

--- a/app/app/Livewire/Traits/HasCard.php
+++ b/app/app/Livewire/Traits/HasCard.php
@@ -131,7 +131,7 @@ trait HasCard
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, ActivateCard::create(
+        $this->handleCommand(ActivateCard::create(
             $this->myself,
             CategoryId::from($category)
         ));
@@ -166,7 +166,7 @@ trait HasCard
             );
             return;
         }
-        $this->coreGameLogic->handle($this->gameId, new SkipCard(
+        $this->handleCommand(new SkipCard(
             $this->myself,
             CategoryId::from($category)
         ));
@@ -186,7 +186,7 @@ trait HasCard
      */
     public function putCardBackOnTopOfPile(string $category): void
     {
-        $this->coreGameLogic->handle($this->gameId, new PutCardBackOnTopOfPile($this->myself, CategoryId::from($category)));
+        $this->handleCommand(new PutCardBackOnTopOfPile($this->myself, CategoryId::from($category)));
         $this->broadcastNotify();
         $this->showCardActionsForCard = null;
     }

--- a/app/app/Livewire/Traits/HasGamePhase.php
+++ b/app/app/Livewire/Traits/HasGamePhase.php
@@ -64,13 +64,13 @@ trait HasGamePhase
             );
             return;
         }
-        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->myself));
+        $this->handleCommand(new EndSpielzug($this->myself));
         $this->broadcastNotify();
     }
 
     public function startSpielzug(): void
     {
-        $this->coreGameLogic->handle($this->gameId, new StartSpielzug($this->myself));
+        $this->handleCommand(new StartSpielzug($this->myself));
         $this->broadcastNotify();
     }
 }

--- a/app/app/Livewire/Traits/HasInvestitionen.php
+++ b/app/app/Livewire/Traits/HasInvestitionen.php
@@ -162,7 +162,7 @@ trait HasInvestitionen
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, BuyInvestmentsForPlayer::create(
+        $this->handleCommand(BuyInvestmentsForPlayer::create(
             $this->myself,
             $investmentId,
             $this->buyInvestmentsForm->amount
@@ -179,7 +179,7 @@ trait HasInvestitionen
     public function closeSellInvestmentsModal(): void
     {
         $stocksBoughtEvent = $this->getGameEvents()->findLast(InvestmentsWereBoughtForPlayer::class);
-        $this->coreGameLogic->handle($this->gameId, DontSellInvestmentsForPlayer::create(
+        $this->handleCommand(DontSellInvestmentsForPlayer::create(
             $this->myself,
             $stocksBoughtEvent->investmentId
         ));
@@ -216,7 +216,7 @@ trait HasInvestitionen
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, SellInvestmentsForPlayerAfterInvestmentByAnotherPlayer::create(
+        $this->handleCommand(SellInvestmentsForPlayerAfterInvestmentByAnotherPlayer::create(
             $this->myself,
             $investmentId,
             $this->sellInvestmentsForm->amount
@@ -287,7 +287,7 @@ trait HasInvestitionen
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, SellInvestmentsForPlayer::create(
+        $this->handleCommand(SellInvestmentsForPlayer::create(
             $this->myself,
             $investmentId,
             $this->sellInvestmentsForm->amount

--- a/app/app/Livewire/Traits/HasJobOffer.php
+++ b/app/app/Livewire/Traits/HasJobOffer.php
@@ -47,10 +47,7 @@ trait HasJobOffer
             );
             return;
         }
-        $this->coreGameLogic->handle(
-            $this->gameId,
-            AcceptJobOffer::create($this->myself, $cardId)
-        );
+        $this->handleCommand(AcceptJobOffer::create($this->myself, $cardId));
 
         $this->jobOfferIsVisible = false;
         $this->broadcastNotify();

--- a/app/app/Livewire/Traits/HasKonjunkturphase.php
+++ b/app/app/Livewire/Traits/HasKonjunkturphase.php
@@ -77,7 +77,7 @@ trait HasKonjunkturphase
             );
             return;
         }
-        $this->coreGameLogic->handle($this->gameId, StartKonjunkturphaseForPlayer::create($this->myself));
+        $this->handleCommand(StartKonjunkturphaseForPlayer::create($this->myself));
         $this->broadcastNotify();
         $this->konjunkturphaseStartScreenPage = 0;
     }
@@ -93,7 +93,7 @@ trait HasKonjunkturphase
             );
             return;
         }
-        $this->coreGameLogic->handle($this->gameId, CompleteMoneysheetForPlayer::create($this->myself));
+        $this->handleCommand(CompleteMoneysheetForPlayer::create($this->myself));
         $this->moneySheetIsVisible = false;
         $this->broadcastNotify();
     }
@@ -116,7 +116,7 @@ trait HasKonjunkturphase
             );
             return;
         }
-        $this->coreGameLogic->handle($this->gameId, MarkPlayerAsReadyForKonjunkturphaseChange::create($this->myself));
+        $this->handleCommand(MarkPlayerAsReadyForKonjunkturphaseChange::create($this->myself));
         $this->broadcastNotify();
     }
 }

--- a/app/app/Livewire/Traits/HasLebenszielphase.php
+++ b/app/app/Livewire/Traits/HasLebenszielphase.php
@@ -48,7 +48,7 @@ trait HasLebenszielphase
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->myself));
+        $this->handleCommand(ChangeLebenszielphase::create($this->myself));
         $this->isChangeLebenszielphaseVisible = true;
 
         /** @var LebenszielphaseWasChanged $event */

--- a/app/app/Livewire/Traits/HasMinijob.php
+++ b/app/app/Livewire/Traits/HasMinijob.php
@@ -30,7 +30,7 @@ trait HasMinijob
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->myself));
+        $this->handleCommand(DoMinijob::create($this->myself));
         $this->broadcastNotify();
         $this->isMinijobVisible = true;
     }

--- a/app/app/Livewire/Traits/HasMoneySheet.php
+++ b/app/app/Livewire/Traits/HasMoneySheet.php
@@ -189,7 +189,7 @@ trait HasMoneySheet
     public function setLebenshaltungskosten(): void
     {
         $this->moneySheetLebenshaltungskostenForm->validate();
-        $this->coreGameLogic->handle($this->gameId, EnterLebenshaltungskostenForPlayer::create(
+        $this->handleCommand(EnterLebenshaltungskostenForPlayer::create(
             $this->myself,
             new MoneyAmount($this->moneySheetLebenshaltungskostenForm->lebenshaltungskosten)
         ));
@@ -212,7 +212,7 @@ trait HasMoneySheet
     public function setSteuernUndAbgaben(): void
     {
         $this->moneySheetSteuernUndAbgabenForm->validate();
-        $this->coreGameLogic->handle($this->gameId, EnterSteuernUndAbgabenForPlayer::create(
+        $this->handleCommand(EnterSteuernUndAbgabenForPlayer::create(
             $this->myself,
             new MoneyAmount($this->moneySheetSteuernUndAbgabenForm->steuernUndAbgaben)
         ));
@@ -246,7 +246,7 @@ trait HasMoneySheet
             if ($shouldBeConcluded) {
                 $concludeInsuranceValidationResult = new ConcludeInsuranceForPlayerAktion($insuranceId)->validate($this->myself, $this->getGameEvents());
                 if ($concludeInsuranceValidationResult->canExecute) {
-                    $this->coreGameLogic->handle($this->gameId, ConcludeInsuranceForPlayer::create($this->myself, $insuranceId));
+                    $this->handleCommand(ConcludeInsuranceForPlayer::create($this->myself, $insuranceId));
                 } else {
                     $insuranceName = InsuranceFinder::getInstance()->findInsuranceById($insuranceId)->description;
                     $this->showBanner('Du hast nicht genug Geld, um die ' . $insuranceName . ' abzuschließen.');
@@ -254,7 +254,7 @@ trait HasMoneySheet
             } else {
                 $cancelInsuranceValidationResult = new CancelInsuranceForPlayerAktion($insuranceId)->validate($this->myself, $this->getGameEvents());
                 if ($cancelInsuranceValidationResult->canExecute) {
-                    $this->coreGameLogic->handle($this->gameId, CancelInsuranceForPlayer::create($this->myself, $insuranceId));
+                    $this->handleCommand(CancelInsuranceForPlayer::create($this->myself, $insuranceId));
                 }else {
                     $insuranceName = InsuranceFinder::getInstance()->findInsuranceById($insuranceId)->description;
                     $this->showBanner('Du kannst die ' . $insuranceName . ' nicht kündigen.');
@@ -267,7 +267,7 @@ trait HasMoneySheet
     public function takeOutALoan(): void
     {
         $loanId = new LoanId($this->takeOutALoanForm->loanId);
-        $this->coreGameLogic->handle($this->gameId, TakeOutALoanForPlayer::create(
+        $this->handleCommand(TakeOutALoanForPlayer::create(
             $this->myself,
             $this->takeOutALoanForm
         ));
@@ -310,7 +310,7 @@ trait HasMoneySheet
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, RepayLoanForPlayer::create(
+        $this->handleCommand(RepayLoanForPlayer::create(
             $this->myself,
             new LoanId($loanId)
         ));

--- a/app/app/Livewire/Traits/HasPreGamePhase.php
+++ b/app/app/Livewire/Traits/HasPreGamePhase.php
@@ -43,9 +43,9 @@ trait HasPreGamePhase
     public function preGameSetNameAndLebensziel(): void
     {
         $this->nameLebenszielForm->validate();
-        $this->coreGameLogic->handle($this->gameId, new SetNameForPlayer($this->myself, $this->nameLebenszielForm->name));
+        $this->handleCommand(new SetNameForPlayer($this->myself, $this->nameLebenszielForm->name));
         if ($this->nameLebenszielForm->lebensziel !== null) {
-            $this->coreGameLogic->handle($this->gameId, new SelectLebensziel($this->myself, LebenszielId::create($this->nameLebenszielForm->lebensziel)));
+            $this->handleCommand(new SelectLebensziel($this->myself, LebenszielId::create($this->nameLebenszielForm->lebensziel)));
         }
 
         $this->broadcastNotify();
@@ -58,8 +58,8 @@ trait HasPreGamePhase
 
     public function startGame(): void
     {
-        $this->coreGameLogic->handle($this->gameId, StartGame::create());
-        $this->coreGameLogic->handle($this->gameId, ChangeKonjunkturphase::create());
+        $this->handleCommand(StartGame::create());
+        $this->handleCommand(ChangeKonjunkturphase::create());
         $this->broadcastNotify();
     }
 }

--- a/app/app/Livewire/Traits/HasQuitJob.php
+++ b/app/app/Livewire/Traits/HasQuitJob.php
@@ -22,7 +22,7 @@ trait HasQuitJob
             );
             return;
         }
-        $this->coreGameLogic->handle($this->gameId, QuitJob::create($this->myself));
+        $this->handleCommand(QuitJob::create($this->myself));
         $this->broadcastNotify();
 
         $this->showBanner("Du hast deinen Job gekündigt.");

--- a/app/app/Livewire/Traits/HasWeiterbildung.php
+++ b/app/app/Livewire/Traits/HasWeiterbildung.php
@@ -73,7 +73,7 @@ trait HasWeiterbildung
             return;
         }
 
-        $this->coreGameLogic->handle($this->gameId, StartWeiterbildung::create($this->myself));
+        $this->handleCommand(StartWeiterbildung::create($this->myself));
 
         $this->isWeiterbildungVisible = true;
         $this->broadcastNotify();
@@ -93,7 +93,7 @@ trait HasWeiterbildung
         $this->weiterbildungForm->validate();
 
         $selectedAnswerId = new AnswerId($this->weiterbildungForm->answer);
-        $this->coreGameLogic->handle($this->gameId, SubmitAnswerForWeiterbildung::create(
+        $this->handleCommand(SubmitAnswerForWeiterbildung::create(
             $this->myself,
             $selectedAnswerId
         ));

--- a/app/disallowed-calls.neon
+++ b/app/disallowed-calls.neon
@@ -40,6 +40,12 @@ parameters:
             method: '*ForTesting*()'
             message: '..forTesting() only allowed in testcases.'
 
+         -  # We always want to use GameUi::handleCommand() which also updates the gameEvents
+            method: 'Domain\CoreGameLogic\DrivingPorts\ForCoreGameLogic::handle()'
+            message: 'use GameUi::handleCommand() instead'
+            allowExceptIn:
+                - app/Livewire/Traits/*
+
     disallowedFunctionCalls:
         -   # We do not want to use helpers which access global state. -> Dependency Injection
             function:


### PR DESCRIPTION
Calling `ForCoreGameLogic::getGameEvents()` all the time was having a really heavy performance impact. Now we use just save it to the GameUi and update it everytime we call a command. To make sure that we don't forget to use the `GameUi::handle()` method, we added a phpstan rule that disallows calls to `ForCoreGameLogic::getGameEvents()` inside of traits.