### PR TITLE
fix: submit empty field does not crash

### DIFF
--- a/app/app/Livewire/Forms/MoneySheetLebenshaltungskostenForm.php
+++ b/app/app/Livewire/Forms/MoneySheetLebenshaltungskostenForm.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Livewire\Forms;
 
 use Livewire\Attributes\Validate;
@@ -8,7 +10,7 @@ use Livewire\Form;
 class MoneySheetLebenshaltungskostenForm extends Form
 {
     #[Validate('required|numeric')]
-    public float $lebenshaltungskosten = 0;
+    public ?float $lebenshaltungskosten = 0;
 
     // just a flag to disable the input field in the view
     public bool $isLebenshaltungskostenInputDisabled = false;

--- a/app/app/Livewire/Forms/MoneySheetSteuernUndAbgabenForm.php
+++ b/app/app/Livewire/Forms/MoneySheetSteuernUndAbgabenForm.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace App\Livewire\Forms;
 
 use Livewire\Attributes\Validate;
@@ -8,7 +10,7 @@ use Livewire\Form;
 class MoneySheetSteuernUndAbgabenForm extends Form
 {
     #[Validate('required|numeric')]
-    public float $steuernUndAbgaben = 0;
+    public ?float $steuernUndAbgaben = 0;
 
     // just a flag to disable the input field in the view
     public bool $isSteuernUndAbgabenInputDisabled = false;

--- a/app/app/Livewire/Forms/TakeOutALoanForm.php
+++ b/app/app/Livewire/Forms/TakeOutALoanForm.php
@@ -15,13 +15,13 @@ class TakeOutALoanForm extends Form
     public string $generalError = '';
 
     #[Validate]
-    public int $loanAmount = 0;
+    public ?int $loanAmount = 0;
 
     #[Validate]
-    public float $totalRepayment = 0;
+    public ?float $totalRepayment = 0;
 
     #[Validate]
-    public float $repaymentPerKonjunkturphase = 0;
+    public ?float $repaymentPerKonjunkturphase = 0;
 
     // public properties needed for validation
     public float $sumOfAllAssets = 0;
@@ -40,21 +40,30 @@ class TakeOutALoanForm extends Form
         $repaymentPeriod = Configuration::REPAYMENT_PERIOD;
         return [
             'loanAmount' => [
-                'required', 'numeric', 'min:1', function ($attribute, $value, $fail) {
+                'required',
+                'numeric',
+                'min:1',
+                function ($attribute, $value, $fail) {
                     if ($this->loanAmount > LoanCalculator::getMaxLoanAmount($this->sumOfAllAssets, $this->salary, $this->obligations, $this->wasPlayerInsolventInThePast)->value) {
                         $fail("Du kannst keinen Kredit aufnehmen, der höher ist als das Kreditlimit.");
                     }
                 }
             ],
             'totalRepayment' => [
-                'required', 'numeric', function ($attribute, $value, $fail) use ($repaymentPeriod) {
+                'required',
+                'numeric',
+                function ($attribute, $value, $fail) use ($repaymentPeriod) {
+                    /** @phpstan-ignore argument.type, argument.type */
                     if (!LoanCalculator::equals($this->totalRepayment, LoanCalculator::getCalculatedTotalRepayment($this->loanAmount, $this->zinssatz))) {
                         $fail("Die Rückzahlung muss dem Kreditbetrag multipliziert mit dem Zinssatz geteilt durch $repaymentPeriod entsprechen.");
                     }
                 }
             ],
             'repaymentPerKonjunkturphase' => [
-                'required', 'numeric', function ($attribute, $value, $fail) use ($repaymentPeriod) {
+                'required',
+                'numeric',
+                function ($attribute, $value, $fail) use ($repaymentPeriod) {
+                    /** @phpstan-ignore argument.type, argument.type */
                     if (!LoanCalculator::equals($this->repaymentPerKonjunkturphase, LoanCalculator::getCalculatedRepaymentPerKonjunkturphase($this->loanAmount, $this->zinssatz))) {
                         $fail("Die Rückzahlung pro Runde muss der Rückzahlungssumme geteilt durch $repaymentPeriod entsprechen.");
                     }
@@ -76,6 +85,6 @@ class TakeOutALoanForm extends Form
 
     public function getCalculatedRepaymentPerKonjunkturphase(): float
     {
-        return LoanCalculator::getCalculatedRepaymentPerKonjunkturphase($this->loanAmount, $this->zinssatz);
+        return LoanCalculator::getCalculatedRepaymentPerKonjunkturphase($this->loanAmount ?? 0, $this->zinssatz);
     }
 }

--- a/app/app/Livewire/Traits/HasMoneySheet.php
+++ b/app/app/Livewire/Traits/HasMoneySheet.php
@@ -105,7 +105,7 @@ trait HasMoneySheet
         $this->takeOutALoanIsVisible = false;
         $this->repaymentFormForLoanId = null;
 
-        match($tab) {
+        match ($tab) {
             ExpensesTabEnum::LIVING_COSTS => $this->initializeLivingCostsForm(),
             ExpensesTabEnum::TAXES => $this->initializeTaxesForm(),
             ExpensesTabEnum::INSURANCES => $this->initializeInsurancesForm(),
@@ -186,7 +186,7 @@ trait HasMoneySheet
             annualIncomeForAllAssets: MoneySheetState::getAnnualIncomeForAllInvestments($this->getGameEvents(), $playerId),
             annualIncome: MoneySheetState::getAnnualIncomeForPlayer($this->getGameEvents(), $playerId),
             annualExpenses: new MoneyAmount(-1 * MoneySheetState::getAnnualExpensesForPlayer($this->getGameEvents(), $playerId)->value),
-            annualExpensesFromPlayerInput: new MoneyAmount (-1 * MoneySheetState::calculateAnnualExpensesFromPlayerInput($this->getGameEvents(), $playerId)->value),
+            annualExpensesFromPlayerInput: new MoneyAmount(-1 * MoneySheetState::calculateAnnualExpensesFromPlayerInput($this->getGameEvents(), $playerId)->value),
             guthabenBeforeKonjunkturphaseChange: $guthabenBeforeKonjunkturphaseChange,
             guthabenAfterKonjunkturphaseChange: $guthabenAfterKonjunkturphaseChange,
             insolvenzabgaben: MoneySheetState::calculateInsolvenzabgabenForPlayer($this->getGameEvents(), $playerId)->negate(),
@@ -198,18 +198,22 @@ trait HasMoneySheet
         $this->moneySheetLebenshaltungskostenForm->validate();
         $this->handleCommand(EnterLebenshaltungskostenForPlayer::create(
             $this->myself,
-            new MoneyAmount($this->moneySheetLebenshaltungskostenForm->lebenshaltungskosten)
+            new MoneyAmount($this->moneySheetLebenshaltungskostenForm->lebenshaltungskosten ?? 0)
         ));
 
         $updatedEvents = $this->coreGameLogic->getGameEvents($this->gameId);
         $resultOfLastInput = MoneySheetState::getResultOfLastLebenshaltungskostenInput($updatedEvents, $this->myself);
 
         if (!$resultOfLastInput->wasSuccessful && $resultOfLastInput->fine->value > 0) {
-            $this->moneySheetLebenshaltungskostenForm->addError('lebenshaltungskosten',
-                "Du hast einen falschen Wert für die Lebenshaltungskosten eingegeben. Dir wurden {$resultOfLastInput->fine->value} € abgezogen. Wir haben den Wert für dich korrigiert.");
+            $this->moneySheetLebenshaltungskostenForm->addError(
+                'lebenshaltungskosten',
+                "Du hast einen falschen Wert für die Lebenshaltungskosten eingegeben. Dir wurden {$resultOfLastInput->fine->value} € abgezogen. Wir haben den Wert für dich korrigiert."
+            );
         } elseif (!$resultOfLastInput->wasSuccessful) {
-            $this->moneySheetLebenshaltungskostenForm->addError('lebenshaltungskosten',
-                "Du hast einen falschen Wert für die Lebenshaltungskosten eingegeben.");
+            $this->moneySheetLebenshaltungskostenForm->addError(
+                'lebenshaltungskosten',
+                "Du hast einen falschen Wert für die Lebenshaltungskosten eingegeben."
+            );
         }
 
         $this->initializeLivingCostsForm();
@@ -221,18 +225,22 @@ trait HasMoneySheet
         $this->moneySheetSteuernUndAbgabenForm->validate();
         $this->handleCommand(EnterSteuernUndAbgabenForPlayer::create(
             $this->myself,
-            new MoneyAmount($this->moneySheetSteuernUndAbgabenForm->steuernUndAbgaben)
+            new MoneyAmount($this->moneySheetSteuernUndAbgabenForm->steuernUndAbgaben ?? 0)
         ));
 
         $updatedEvents = $this->coreGameLogic->getGameEvents($this->gameId);
         $resultOfLastInput = MoneySheetState::getResultOfLastSteuernUndAbgabenInput($updatedEvents, $this->myself);
 
         if (!$resultOfLastInput->wasSuccessful && $resultOfLastInput->fine->value > 0) {
-            $this->moneySheetSteuernUndAbgabenForm->addError('steuernUndAbgaben',
-                "Du hast einen falschen Wert für die Steuern und Abgaben eingegeben. Dir wurden {$resultOfLastInput->fine->value} € abgezogen. Wir haben den Wert für dich korrigiert.");
+            $this->moneySheetSteuernUndAbgabenForm->addError(
+                'steuernUndAbgaben',
+                "Du hast einen falschen Wert für die Steuern und Abgaben eingegeben. Dir wurden {$resultOfLastInput->fine->value} € abgezogen. Wir haben den Wert für dich korrigiert."
+            );
         } elseif (!$resultOfLastInput->wasSuccessful) {
-            $this->moneySheetSteuernUndAbgabenForm->addError('steuernUndAbgaben',
-                "Du hast einen falschen Wert für die Steuern und Abgaben eingegeben.");
+            $this->moneySheetSteuernUndAbgabenForm->addError(
+                'steuernUndAbgaben',
+                "Du hast einen falschen Wert für die Steuern und Abgaben eingegeben."
+            );
         }
 
         $this->initializeTaxesForm();
@@ -241,7 +249,7 @@ trait HasMoneySheet
 
     public function setInsurances(): void
     {
-        foreach($this->moneySheetInsurancesForm->insurances as $insuranceFromForm) {
+        foreach ($this->moneySheetInsurancesForm->insurances as $insuranceFromForm) {
             $insuranceId = InsuranceId::create($insuranceFromForm['id']);
             $shouldBeConcluded = $insuranceFromForm['value'] === true;
             $currentlyConcluded = MoneySheetState::doesPlayerHaveThisInsurance($this->getGameEvents(), $this->myself, $insuranceId);
@@ -262,7 +270,7 @@ trait HasMoneySheet
                 $cancelInsuranceValidationResult = new CancelInsuranceForPlayerAktion($insuranceId)->validate($this->myself, $this->getGameEvents());
                 if ($cancelInsuranceValidationResult->canExecute) {
                     $this->handleCommand(CancelInsuranceForPlayer::create($this->myself, $insuranceId));
-                }else {
+                } else {
                     $insuranceName = InsuranceFinder::getInstance()->findInsuranceById($insuranceId)->description;
                     $this->showBanner('Du kannst die ' . $insuranceName . ' nicht kündigen: ' . $cancelInsuranceValidationResult->reason);
                 }
@@ -297,7 +305,7 @@ trait HasMoneySheet
             $this->takeOutALoanForm->generalError = "Du hast falsche Werte für den Kredit eingegeben.";
         } else {
             $this->takeOutALoanForm->resetValidation();
-            $loanAmount = new MoneyAmount($this->takeOutALoanForm->loanAmount);
+            $loanAmount = new MoneyAmount($this->takeOutALoanForm->loanAmount ?? 0);
             $this->showBanner("Du hast einen Kredit über {$loanAmount->formatWithoutHtml()} aufgenommen.");
             $this->closeTakeOutALoan();
         }

--- a/app/src/CoreGameLogic/Feature/Spielzug/Aktion/TakeOutALoanForPlayerAktion.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/Aktion/TakeOutALoanForPlayerAktion.php
@@ -32,8 +32,7 @@ class TakeOutALoanForPlayerAktion extends Aktion
      */
     public function __construct(
         private readonly TakeOutALoanForm|null $takeOutALoanForm = null
-    ) {
-    }
+    ) {}
 
     public function validate(PlayerId $playerId, GameEvents $gameEvents): AktionValidationResult
     {
@@ -62,6 +61,15 @@ class TakeOutALoanForPlayerAktion extends Aktion
         $validationResult = $this->validate($playerId, $gameEvents);
         if (!$validationResult->canExecute) {
             throw new RuntimeException('Cannot take out a loan: ' . $validationResult->reason, 1756200359);
+        }
+
+        if (
+            $this->takeOutALoanForm->loanAmount === null ||
+            $this->takeOutALoanForm->totalRepayment === null ||
+            $this->takeOutALoanForm->repaymentPerKonjunkturphase === null
+        ) {
+            // This should never happen, since $this->takeOutALoanForm->validate() should catch this
+            throw new \RuntimeException("Required fields must not be empty");
         }
 
         $inputLoanData = new LoanData(


### PR DESCRIPTION
Submitting an empty field in "Steuern und Abgaben", "Kredit aufnehmen" and "Lebenshaltungskosten" would cause an exception on the next submit action. The form parameters need to be optional to prevent that.

Closes: #511
Closes: #512
Closes: #513