### PR TITLE
fix: create random games with correct player count

### DIFF
--- a/app/app/Filament/Admin/Resources/CourseResource/Pages/ViewCourse.php
+++ b/app/app/Filament/Admin/Resources/CourseResource/Pages/ViewCourse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace App\Filament\Admin\Resources\CourseResource\Pages;
@@ -15,12 +16,72 @@ use Domain\CoreGameLogic\PlayerId;
 use Filament\Actions\Action;
 use Filament\Actions\ImportAction;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 
 class ViewCourse extends ViewRecord
 {
     protected static string $resource = CourseResource::class;
+
+    /**
+     * @param Collection<int, Player> $playersCollection
+     * @return array<array<Player>>
+     */
+    private static function createRandomGameGroups(Collection $playersCollection): array
+    {
+        $allPlayers = [];
+
+        foreach ($playersCollection as $player) {
+            $allPlayers[] = $player;
+        }
+
+        // We need at least two players
+        if (count($allPlayers) < 2) {
+            return [];
+        }
+
+        // we want random groups, so we shuffle all players before slicing the array into groups
+        shuffle($allPlayers);
+
+        $gameGroups = [];
+
+        /**
+         * WHY:
+         * We need at least 2 players in a game. If we fill all games with four players we may end up
+         * with one group that only has 1 player. That is the case when playerCount % 4 === 1. In that
+         * case we can simply create one group with 2 players and one group with 3 players. The remaining
+         * players can be put in full groups.
+         */
+        if (count($allPlayers) > 4 && count($allPlayers) % 4 === 1) {
+            $gameGroups[] = array_slice($allPlayers, 0, 3);
+            $gameGroups[] = array_slice($allPlayers, 3, 2);
+            $allPlayers = array_slice($allPlayers, 5);
+        }
+
+        /**
+         * Fill the remaining games with up to 4 players (unless there are less than 4 left)
+         */
+        $playersPerGame = 4;
+        $numberOfGames = (int) ceil(count($allPlayers) / $playersPerGame);
+        for ($i = 0; $i < $numberOfGames; $i++) {
+            $gameGroups[] = array_slice($allPlayers, $i * $playersPerGame, $playersPerGame);
+        }
+
+        return $gameGroups;
+    }
+
+    /**
+     * Proxy method to test the private function `createRandomGameGroups`.
+     * Calling `...ForTesting` functions outside of test code will be caught by phpstan.
+     * @param Collection<int, Player> $playersCollection
+     * @return array<array<Player>>
+     */
+    public static function createRandomGameGroupsForTesting(Collection $playersCollection): array
+    {
+        return self::createRandomGameGroups($playersCollection);
+    }
 
     protected function getHeaderActions(): array
     {
@@ -34,35 +95,31 @@ class ViewCourse extends ViewRecord
                 ]),
             Action::make('Spiele erstellen')
                 ->action(function (ForCoreGameLogic $coreGameLogic) {
+
                     /** @var Course $course */
                     $course = $this->record;
-
-                    $allPlayers = $course->players;
-                    $players = [];
-                    // TODO players who created their own game are not included at this point
-                    foreach ($allPlayers as $player) {
-                        // check if player is already in a game for this course
-                        /** @phpstan-ignore staticMethod.dynamicCall, staticMethod.dynamicCall */
-                        if ($player->games()->where('course_id', $course->id)->count() === 0) {
-                            $players[] = $player;
-                        }
-                    }
-
                     // current user is the creator of the games
                     $panel = Filament::getCurrentPanel();
                     $user = $panel?->auth()->user();
 
-                    // TODO add min players check (2)
-                    $playersPerGame = 4;
-                    $numberOfGames = (int) ceil(count($players) / $playersPerGame);
-                    for ($i = 0; $i < $numberOfGames; $i++) {
+                    $gameGroups = self::createRandomGameGroups($course->players);
+
+                    if (count($gameGroups) === 0) {
+                        Notification::make()
+                            ->title('Es werden mindestens zwei Spielende benötigt, um Spiele zu erstellen')
+                            ->warning()
+                            ->send();
+                        return;
+                    }
+
+                    foreach ($gameGroups as $group) {
                         $game = new Game();
                         /** @phpstan-ignore assign.propertyType */
                         $game->id = Str::ulid();
                         $game->course()->associate($course);
                         $game->creator()->associate($user); // no creator
                         $game->save();
-                        $game->players()->attach(array_slice($players, $i * $playersPerGame, $playersPerGame));
+                        $game->players()->attach($group);
                         $coreGameLogic->handle(GameId::fromString((string) $game->id), StartPreGame::create(
                             numberOfPlayers: count($game->players)
                         )->withFixedPlayerIds(

--- a/app/tests/Unit/App/Filament/Admin/Resources/CourseResource/Pages/ViewCourseTest.php
+++ b/app/tests/Unit/App/Filament/Admin/Resources/CourseResource/Pages/ViewCourseTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Admin\Resources\CourseResource\Pages\ViewCourse;
+use App\Models\Player;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Tests\TestCase;
+
+beforeEach(function () {
+    /** @var TestCase $this */
+});
+
+describe('create random game groups', function () {
+    it('returns an empty array if there are not enough players', function () {
+        /** @var testcase $this */
+        // test with one player
+        $playerGroups = new Collection([
+            User::factory()->count(1)->make(),
+        ]);
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect($actualGameGroups)->toBe([]);
+
+        // test with no players
+        $playerGroups = new Collection([]);
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect($actualGameGroups)->toBe([]);
+    });
+
+    it('returns an array with one group of two players for two players', function () {
+        /** @var testcase $this */
+
+        [$player1, $player2] = User::factory()->count(2)->make();
+        $playerGroups = new Collection([
+            $player1,
+            $player2,
+        ]);
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect(count($actualGameGroups))->toBe(1, "actualGameGroups should containt 1 game group")
+            ->and(count($actualGameGroups[0]))->toBe(2, "Game group should contain 2 players");
+        $actualPlayerIds = array_map(fn($player) => $player->name, $actualGameGroups[0]);
+        expect($actualPlayerIds)->toContainEqual($player1->name, $player2->name);
+    });
+
+    it('returns one group with 2 and one with 3 player, when 5 players are in a course', function () {
+        /** @var testcase $this */
+        $players = User::factory()->count(5)->make();
+        $playerGroups = new Collection($players);
+
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect(count($actualGameGroups))->toBe(2, "actualGameGroups should containt 2 game groups");
+
+        $actualGroupSizes = array_map(fn($group) => count($group), $actualGameGroups);
+        expect($actualGroupSizes)->toContain(2, 3);
+    });
+
+    it('works for exactly 4 players in a course', function () {
+        /** @var testcase $this */
+        $players = User::factory()->count(4)->make();
+        $playerGroups = new Collection($players);
+
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect(count($actualGameGroups))->toBe(1, "actualGameGroups should containt 4 game groups");
+
+        $actualGroupSizes = array_map(fn($group) => count($group), $actualGameGroups);
+        expect($actualGroupSizes)->toEqual([4]);
+    });
+
+    it('works for course numbers divisible by 4', function () {
+        /** @var testcase $this */
+        $players = User::factory()->count(16)->make();
+        $playerGroups = new Collection($players);
+
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect(count($actualGameGroups))->toBe(4, "actualGameGroups should containt 4 game groups");
+
+        $actualGroupSizes = array_map(fn($group) => count($group), $actualGameGroups);
+        expect($actualGroupSizes)->toEqual([4, 4, 4, 4]);
+    });
+
+    it('works for course numbers divisible by 4 with a rest of 1', function () {
+        /** @var testcase $this */
+        $players = User::factory()->count(17)->make();
+        $playerGroups = new Collection($players);
+
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        expect(count($actualGameGroups))->toBe(5, "actualGameGroups should containt 4 game groups");
+
+        $actualGroupSizes = array_map(fn($group) => count($group), $actualGameGroups);
+        expect($actualGroupSizes)->toEqual([3, 2, 4, 4, 4]);
+    });
+
+
+    it('assigns every player to a game', function () {
+        /** @var testcase $this */
+        $players = User::factory()->count(17)->make();
+        $expectedPlayersInGroups = [];
+        foreach ($players as $player) {
+            $expectedPlayersInGroups[] = $player->name;
+        }
+        $playerGroups = new Collection($players);
+
+        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
+        $actualPlayersInGroups = [];
+        foreach ($actualGameGroups as $group) {
+            foreach ($group as $player) {
+                $actualPlayersInGroups[] = $player->name;
+            };
+        };
+
+        expect($actualPlayersInGroups)->toHaveCount(17)
+            ->and($actualPlayersInGroups)->toContain(...$expectedPlayersInGroups);
+    });
+});


### PR DESCRIPTION
Creating games now creates random groups of two to four players. It is also possible to create a new set of games.

Closes: #546
Closes: #548