### PR TITLE
Prevent players from finishing the game while having open loans

### DIFF
--- a/app/src/CoreGameLogic/Feature/Spielzug/Aktion/ChangeLebenszielphaseAktion.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/Aktion/ChangeLebenszielphaseAktion.php
@@ -8,6 +8,7 @@ use Domain\CoreGameLogic\EventStore\GameEvents;
 use Domain\CoreGameLogic\EventStore\GameEventsToPersist;
 use Domain\CoreGameLogic\Feature\Spielzug\Aktion\Validator\DoesNotSkipTurnValidator;
 use Domain\CoreGameLogic\Feature\Spielzug\Aktion\Validator\HasPlayerEnoughResourcesForLebenszielphasenChangeValidator;
+use Domain\CoreGameLogic\Feature\Spielzug\Aktion\Validator\HasPlayerNoOpenLoansWhenFinishingValidator;
 use Domain\CoreGameLogic\Feature\Spielzug\Aktion\Validator\IsPlayersTurnValidator;
 use Domain\CoreGameLogic\Feature\Spielzug\Dto\AktionValidationResult;
 use Domain\CoreGameLogic\Feature\Spielzug\Event\LebenszielphaseWasChanged;
@@ -26,7 +27,8 @@ class ChangeLebenszielphaseAktion extends Aktion
         $validatorChain = new IsPlayersTurnValidator();
         $validatorChain
             ->setNext(new DoesNotSkipTurnValidator())
-            ->setNext(new HasPlayerEnoughResourcesForLebenszielphasenChangeValidator());
+            ->setNext(new HasPlayerEnoughResourcesForLebenszielphasenChangeValidator())
+            ->setNext(new HasPlayerNoOpenLoansWhenFinishingValidator());
 
         return $validatorChain->validate($gameEvents, $playerId);
     }

--- a/app/src/CoreGameLogic/Feature/Spielzug/Aktion/Validator/HasPlayerNoOpenLoansWhenFinishingValidator.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/Aktion/Validator/HasPlayerNoOpenLoansWhenFinishingValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\CoreGameLogic\Feature\Spielzug\Aktion\Validator;
+
+use Domain\CoreGameLogic\EventStore\GameEvents;
+use Domain\CoreGameLogic\Feature\Moneysheet\State\MoneySheetState;
+use Domain\CoreGameLogic\Feature\Spielzug\Dto\AktionValidationResult;
+use Domain\CoreGameLogic\Feature\Spielzug\State\PlayerState;
+use Domain\CoreGameLogic\PlayerId;
+use Domain\Definitions\Card\ValueObject\LebenszielPhaseId;
+
+final class HasPlayerNoOpenLoansWhenFinishingValidator extends AbstractValidator
+{
+    public function validate(GameEvents $gameEvents, PlayerId $playerId): AktionValidationResult
+    {
+        $currentPhase = PlayerState::getCurrentLebenszielphaseIdForPlayer($gameEvents, $playerId);
+
+        if ($currentPhase === LebenszielPhaseId::PHASE_3) {
+            $openLoans = MoneySheetState::getOpenLoansForPlayer($gameEvents, $playerId);
+            if (count($openLoans) > 0) {
+                return new AktionValidationResult(
+                    canExecute: false,
+                    reason: 'Du kannst das Spiel nicht beenden, solange du noch offene Kredite hast',
+                );
+            }
+        }
+
+        return parent::validate($gameEvents, $playerId);
+    }
+}

--- a/app/tests/Unit/CoreGameLogic/Feature/Spielzug/SpielzugCommandHandlerTest.php
+++ b/app/tests/Unit/CoreGameLogic/Feature/Spielzug/SpielzugCommandHandlerTest.php
@@ -24,6 +24,9 @@ use Domain\CoreGameLogic\Feature\Spielzug\Command\SkipCard;
 use Domain\CoreGameLogic\Feature\Spielzug\Command\StartSpielzug;
 use Domain\CoreGameLogic\Feature\Spielzug\Command\StartWeiterbildung;
 use Domain\CoreGameLogic\Feature\Spielzug\Command\SubmitAnswerForWeiterbildung;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\RepayLoanForPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\TakeOutALoanForPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\LoanWasTakenOutForPlayer;
 use Domain\CoreGameLogic\Feature\Spielzug\Event\CardWasActivated;
 use Domain\CoreGameLogic\Feature\Spielzug\Event\CardWasPutBackOnTopOfPile;
 use Domain\CoreGameLogic\Feature\Spielzug\Event\JobOfferWasAccepted;
@@ -1311,6 +1314,151 @@ describe('handleChangeLebenszielphase', function () {
         expect(PlayerState::getCurrentLebenszielphaseIdForPlayer($gameEventsAfterPhaseThree, $this->players[0]))
             ->toEqual(LebenszielPhaseId::PHASE_3)
             ->and(GamePhaseState::hasAnyPlayerFinishedLebensziel($gameEventsAfterPhaseThree))->toBeTrue();
+    });
+
+    it('throws an exception when the player tries to finish the Lebensziel while having open loans', function () {
+        /** @var TestCase $this */
+        $cardsForTesting = [
+            new KategorieCardDefinition(
+                id: new CardId('phase1'),
+                categoryId: CategoryId::BILDUNG_UND_KARRIERE,
+                title: 'for testing',
+                description: '...',
+                resourceChanges: new ResourceChanges(
+                    guthabenChange: new MoneyAmount(+2000000),
+                    zeitsteineChange: +1,
+                    bildungKompetenzsteinChange: +5,
+                    freizeitKompetenzsteinChange: +5,
+                ),
+            ),
+            new KategorieCardDefinition(
+                id: new CardId('phase2'),
+                categoryId: CategoryId::BILDUNG_UND_KARRIERE,
+                title: 'for testing',
+                description: '...',
+                phaseId: LebenszielPhaseId::PHASE_2,
+                resourceChanges: new ResourceChanges(
+                    zeitsteineChange: +1,
+                    bildungKompetenzsteinChange: +5,
+                    freizeitKompetenzsteinChange: +5,
+                ),
+            ),
+            new KategorieCardDefinition(
+                id: new CardId('phase3'),
+                categoryId: CategoryId::BILDUNG_UND_KARRIERE,
+                title: 'for testing',
+                description: '...',
+                phaseId: LebenszielPhaseId::PHASE_3,
+                resourceChanges: new ResourceChanges(
+                    zeitsteineChange: +1,
+                    bildungKompetenzsteinChange: +5,
+                    freizeitKompetenzsteinChange: +5,
+                ),
+            ),
+        ];
+        $this->startNewKonjunkturphaseWithCardsOnTop($cardsForTesting);
+
+        // Progress through PHASE_1 -> PHASE_2
+        $this->coreGameLogic->handle($this->gameId, ActivateCard::create($this->players[0], CategoryId::BILDUNG_UND_KARRIERE));
+        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Progress through PHASE_2 -> PHASE_3
+        $this->coreGameLogic->handle($this->gameId, ActivateCard::create($this->players[0], CategoryId::BILDUNG_UND_KARRIERE));
+        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Now in PHASE_3, take out a loan to create debt
+        $this->coreGameLogic->handle($this->gameId, TakeOutALoanForPlayer::create($this->players[0], 10000));
+
+        // Activate the phase 3 card to get resources
+        $this->coreGameLogic->handle($this->gameId, ActivateCard::create($this->players[0], CategoryId::BILDUNG_UND_KARRIERE));
+
+        // Attempt to finish - should fail because the player has an open loan
+        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->players[0]));
+    })->throws(
+        RuntimeException::class,
+        'Cannot Change Lebensphase: Du kannst das Spiel nicht beenden, solange du noch offene Kredite hast',
+        1751619852
+    );
+
+    it('allows finishing the Lebensziel after the player has repaid all open loans', function () {
+        /** @var TestCase $this */
+        $cardsForTesting = [
+            new KategorieCardDefinition(
+                id: new CardId('phase1'),
+                categoryId: CategoryId::BILDUNG_UND_KARRIERE,
+                title: 'for testing',
+                description: '...',
+                resourceChanges: new ResourceChanges(
+                    guthabenChange: new MoneyAmount(+2000000),
+                    zeitsteineChange: +1,
+                    bildungKompetenzsteinChange: +5,
+                    freizeitKompetenzsteinChange: +5,
+                ),
+            ),
+            new KategorieCardDefinition(
+                id: new CardId('phase2'),
+                categoryId: CategoryId::BILDUNG_UND_KARRIERE,
+                title: 'for testing',
+                description: '...',
+                phaseId: LebenszielPhaseId::PHASE_2,
+                resourceChanges: new ResourceChanges(
+                    zeitsteineChange: +1,
+                    bildungKompetenzsteinChange: +5,
+                    freizeitKompetenzsteinChange: +5,
+                ),
+            ),
+            new KategorieCardDefinition(
+                id: new CardId('phase3'),
+                categoryId: CategoryId::BILDUNG_UND_KARRIERE,
+                title: 'for testing',
+                description: '...',
+                phaseId: LebenszielPhaseId::PHASE_3,
+                resourceChanges: new ResourceChanges(
+                    zeitsteineChange: +1,
+                    bildungKompetenzsteinChange: +5,
+                    freizeitKompetenzsteinChange: +5,
+                ),
+            ),
+        ];
+        $this->startNewKonjunkturphaseWithCardsOnTop($cardsForTesting);
+
+        // Progress through PHASE_1 -> PHASE_2
+        $this->coreGameLogic->handle($this->gameId, ActivateCard::create($this->players[0], CategoryId::BILDUNG_UND_KARRIERE));
+        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Progress through PHASE_2 -> PHASE_3
+        $this->coreGameLogic->handle($this->gameId, ActivateCard::create($this->players[0], CategoryId::BILDUNG_UND_KARRIERE));
+        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Now in PHASE_3, take out a loan to create debt
+        $this->coreGameLogic->handle($this->gameId, TakeOutALoanForPlayer::create($this->players[0], 10000));
+
+        // Repay the loan
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        /** @var LoanWasTakenOutForPlayer $loanEvent */
+        $loanEvent = $gameEvents->findLast(LoanWasTakenOutForPlayer::class);
+        $this->coreGameLogic->handle($this->gameId, RepayLoanForPlayer::create($this->players[0], $loanEvent->loanId));
+
+        // Activate the phase 3 card to get resources
+        $this->coreGameLogic->handle($this->gameId, ActivateCard::create($this->players[0], CategoryId::BILDUNG_UND_KARRIERE));
+
+        // Finish the game - should succeed because the loan has been repaid
+        $this->coreGameLogic->handle($this->gameId, ChangeLebenszielphase::create($this->players[0]));
+
+        $gameEventsAfterFinish = $this->coreGameLogic->getGameEvents($this->gameId);
+        expect(GamePhaseState::hasAnyPlayerFinishedLebensziel($gameEventsAfterFinish))->toBeTrue();
     });
 });
 

--- a/docs/2026_03_19_Prevent_Finishing_Game_While_In_Debt.md
+++ b/docs/2026_03_19_Prevent_Finishing_Game_While_In_Debt.md
@@ -1,0 +1,37 @@
+# Plan: Prevent players from finishing the game while in debt
+
+## Context
+Players can currently complete the game (finish Phase 3 of their Lebensziel) even while holding open loans. For a financial literacy game, this undermines the educational message. We need a validation that blocks game completion when the player has outstanding debt.
+
+## Approach: TDD (Red → Green)
+
+### Step 1: Write the red test
+**File:** `app/tests/Unit/CoreGameLogic/Feature/Spielzug/SpielzugCommandHandlerTest.php`
+
+Add a test inside the `describe('handleChangeLebenszielphase', ...)` block that:
+1. Sets up 3 phase cards with generous resources (same pattern as the existing "finishes Lebensziel" test at line 1248)
+2. Progresses the player through PHASE_1 → PHASE_2 → PHASE_3
+3. Takes out a loan via `TakeOutALoanForPlayer::create($this->players[0], 10000)`
+4. Activates the phase 3 card, then attempts `ChangeLebenszielphase`
+5. Expects `RuntimeException` with message `'Cannot Change Lebensphase: Du kannst das Spiel nicht beenden, solange du noch offene Kredite hast'` and code `1751619852`
+
+### Step 2: Create the validator
+**New file:** `app/src/CoreGameLogic/Feature/Spielzug/Aktion/Validator/HasPlayerNoOpenLoansWhenFinishingValidator.php`
+
+- Extends `AbstractValidator`
+- Only checks when `currentPhase === LebenszielPhaseId::PHASE_3` (earlier transitions pass through)
+- Uses `MoneySheetState::getOpenLoansForPlayer()` — if non-empty, returns failing `AktionValidationResult`
+- Otherwise delegates to `parent::validate()`
+
+### Step 3: Wire into the validation chain
+**File:** `app/src/CoreGameLogic/Feature/Spielzug/Aktion/ChangeLebenszielphaseAktion.php`
+
+Append `HasPlayerNoOpenLoansWhenFinishingValidator` to the end of the existing chain in `validate()`:
+```
+IsPlayersTurnValidator → DoesNotSkipTurnValidator → HasPlayerEnoughResourcesForLebenszielphasenChangeValidator → HasPlayerNoOpenLoansWhenFinishingValidator
+```
+
+## Verification
+1. `mise pest tests/Unit/CoreGameLogic/Feature/Spielzug/SpielzugCommandHandlerTest.php --filter="open loans"` — new test passes
+2. `mise pest` — no regressions (existing "finishes Lebensziel" test has no loans, so it still passes)
+3. `mise phpstan` — static analysis clean


### PR DESCRIPTION
Add validation to ChangeLebenszielphaseAktion that blocks game completion (PHASE_3 finish) when the player still has outstanding loans. Earlier phase transitions remain unaffected.

  - Add HasPlayerNoOpenLoansWhenFinishingValidator
  - Wire validator into ChangeLebenszielphase validation chain
  - Add tests for rejection with open loans and success after repayment
  - Add plan doc for the feature