### PR TITLE
fix: do not preselect Lebensziel

### DIFF
--- a/app/app/Livewire/Traits/HasPreGamePhase.php
+++ b/app/app/Livewire/Traits/HasPreGamePhase.php
@@ -30,7 +30,7 @@ trait HasPreGamePhase
     public function mountHasPreGamePhase(): void
     {
         $this->nameForm->name = PlayerState::getNameForPlayerOrNull($this->getGameEvents(), $this->myself) ?? '';
-        $this->lebenszielForm->lebensziel = PlayerState::getLebenszielDefinitionForPlayerOrNull($this->getGameEvents(), $this->myself)->id->value ?? LebenszielFinder::getAllLebensziele()[0]->id->value;
+        $this->lebenszielForm->lebensziel = PlayerState::getLebenszielDefinitionForPlayerOrNull($this->getGameEvents(), $this->myself)?->id->value;
     }
 
     public function renderPreGamePhase(): View

--- a/app/resources/views/components/pregame/selectLebensziel.blade.php
+++ b/app/resources/views/components/pregame/selectLebensziel.blade.php
@@ -6,7 +6,7 @@
     <div class="form-group">
         <label class="sr-only" for="lebensziel">Lebensziele</label>
         <select id="lebensziel" name="lebensziel" class="form-group__input" wire:model="lebenszielForm.lebensziel" wire:change="selectLebensZiel($event.target.value)">
-            <option value="" disabled>-- Wähle Dein Lebensziel --</option>
+            <option value="">-- Wähle Dein Lebensziel --</option>
             @foreach($lebensziele as $lebensziel)
                 <option value="{{ $lebensziel->id->value }}">{{ $lebensziel->name }}</option>
             @endforeach
@@ -23,5 +23,8 @@
     @endforeach
 
     @error('lebenszielForm.lebensziel') <span class="form__error">{{ $message }}</span> @enderror
-    <x-form.submit>Weiter</x-form.submit>
+    <x-form.submit
+        :class="$lebenszielForm->lebensziel === null ? 'button--disabled' : ''"
+        :disabled="$lebenszielForm->lebensziel === null"
+    >Weiter</x-form.submit>
 </form>


### PR DESCRIPTION
In Lebenszielauswahl, the default value is now null (no selection made). This disables the "weiter" button and prevents the player from accidentally clicking too fast (e.g. because of a flaky connection) and selecting the first Lebensziel by accident.

Fixes: #639