### PR TITLE
fix: make important buttons more accessible

### DIFF
--- a/app/resources/views/components/sidebar/sidebar.blade.php
+++ b/app/resources/views/components/sidebar/sidebar.blade.php
@@ -30,6 +30,17 @@
 
     @if ($this->currentPlayerIsMyself())
         <div class="sidebar__actions" x-show="!eventLogOpen">
+            <button
+                type="button"
+                @class([
+                    "button",
+                    "button--type-primary",
+                    "button--disabled" => !$this->canEndSpielzug()->canExecute,
+                    $this->getPlayerColorClass()
+                ])
+                wire:click="spielzugAbschliessen()">
+                Spielzug beenden
+            </button>
             @if (PlayerState::getJobForPlayer($this->gameEvents, $playerId) !== null)
                 <button class="button button--type-secondary" wire:click="showIncomeTab('salary')">
                     <span>Mein Job: <x-money-amount :value="PlayerState::getCurrentGehaltForPlayer($this->gameEvents, $playerId)" /></span>
@@ -47,17 +58,6 @@
             </button>
             <button class="button button--type-secondary" wire:click="showExpensesTab('{{ ExpensesTabEnum::INSURANCES }}')">
                 <span>Versicherung abschließen</span> <i class="icon-dots" aria-hidden="true"></i>
-            </button>
-            <button
-                type="button"
-                @class([
-                    "button",
-                    "button--type-primary",
-                    "button--disabled" => !$this->canEndSpielzug()->canExecute,
-                    $this->getPlayerColorClass()
-                ])
-                wire:click="spielzugAbschliessen()">
-                Spielzug beenden
             </button>
         </div>
     @endif

--- a/app/resources/views/livewire/screens/konjunkturphaseStart.css
+++ b/app/resources/views/livewire/screens/konjunkturphaseStart.css
@@ -39,4 +39,7 @@
     justify-content: space-between;
     align-items: center;
     border-top: 1px solid var(--color-primary);
+    position: sticky;
+    bottom: 0;
+    z-index: var(--z-index-footer);
 }

--- a/app/resources/views/livewire/screens/pregame.css
+++ b/app/resources/views/livewire/screens/pregame.css
@@ -26,6 +26,12 @@
     justify-content: center;
     align-items: center;
 
+    > .button {
+        z-index: var(--z-index-footer);
+        position: sticky;
+        bottom: var(--spacing-200);
+    }
+
     .lebensziel__phase-kompetenzen {
         display: grid;
         grid-template-columns: 1fr 2fr;


### PR DESCRIPTION
Sometime the "weiter" or "Spielzug Beenden" buttons can be hidden below the fold (player needs to scroll to see them). Often times players did not realize that and waited for something to happen.

To address this, we moved the "Spielzug Beenden" button up and made some "weiter" buttons sticky.

Fixes: #634