### PR TITLE
feat: add transaction history for investments

### DIFF
--- a/app/resources/views/components/gameboard/investitionen/investitionen-crypto-modal.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/investitionen-crypto-modal.blade.php
@@ -63,5 +63,6 @@
                 unit="Coin"
             />
         </div>
+        <x-gameboard.investitionen.transaction-history :game-events="$gameEvents" :player-id="$this->myself" />
     @endif
 @endsection

--- a/app/resources/views/components/gameboard/investitionen/investitionen-etf-modal.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/investitionen-etf-modal.blade.php
@@ -64,5 +64,6 @@
                 unit="ETF"
             />
         </div>
+        <x-gameboard.investitionen.transaction-history :game-events="$gameEvents" :player-id="$this->myself" />
     @endif
 @endsection

--- a/app/resources/views/components/gameboard/investitionen/investitionen-immobilien-modal.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/investitionen-immobilien-modal.blade.php
@@ -73,5 +73,6 @@
                 </div>
             </div>
         </div>
+        <x-gameboard.investitionen.transaction-history :game-events="$gameEvents" :player-id="$this->myself" />
     @endif
 @endsection

--- a/app/resources/views/components/gameboard/investitionen/investitionen-stocks-modal.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/investitionen-stocks-modal.blade.php
@@ -56,5 +56,6 @@
                 :investmentType="InvestmentId::BETA_PEAR"
                 :game-Events="$gameEvents"/>
         </div>
+        <x-gameboard.investitionen.transaction-history :game-events="$gameEvents" :player-id="$this->myself" />
     @endif
 @endsection

--- a/app/resources/views/components/gameboard/investitionen/transaction-history.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/transaction-history.blade.php
@@ -1,0 +1,46 @@
+@use('Domain\CoreGameLogic\Feature\Spielzug\State\TransactionHistoryState')
+
+@props([
+    'gameEvents' => null,
+    'playerId' => null,
+])
+
+@php
+    $transactions = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $playerId);
+@endphp
+
+<div class="transaction-history">
+    <h4 class="transaction-history__title">Transaktionshistorie</h4>
+    @if (count($transactions) === 0)
+        <p class="transaction-history__empty">Noch keine Transaktionen</p>
+    @else
+        <div class="transaction-history__table-wrapper">
+            <table class="transaction-history__table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>Zug</th>
+                        <th>Anlageart</th>
+                        <th>Typ</th>
+                        <th>Menge</th>
+                        <th>Kurs</th>
+                        <th>Besitz danach</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($transactions as $transaction)
+                        <tr>
+                            <td><i class="{{ $transaction->iconClass }}" aria-hidden="true"></i></td>
+                            <td>{{ $transaction->playerTurn->value }}</td>
+                            <td>{{ $transaction->assetName }}</td>
+                            <td>{{ $transaction->type }}</td>
+                            <td>{{ $transaction->amount }}</td>
+                            <td><x-money-amount :value="$transaction->price" /></td>
+                            <td>{{ $transaction->holdingAfter }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+</div>

--- a/app/resources/views/components/gameboard/investitionen/transactionHistory.css
+++ b/app/resources/views/components/gameboard/investitionen/transactionHistory.css
@@ -1,0 +1,41 @@
+.transaction-history {
+    border-radius: 10px;
+    background-color: var(--color-cards-bg);
+    padding: var(--spacing-100);
+    margin-top: var(--spacing-100);
+}
+
+.transaction-history__title {
+    margin-bottom: var(--spacing-100);
+}
+
+.transaction-history__empty {
+    color: var(--color-grey);
+    font-style: italic;
+}
+
+.transaction-history__table-wrapper {
+    overflow-x: auto;
+}
+
+.transaction-history__table {
+    display: table;
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-sm);
+
+    th, td {
+        padding: var(--spacing-50) var(--spacing-100);
+        text-align: left;
+        white-space: nowrap;
+    }
+
+    th {
+        border-bottom: 2px solid var(--color-primary);
+        font-weight: var(--font-weight-bold);
+    }
+
+    td {
+        border-bottom: 1px solid var(--color-grey);
+    }
+}

--- a/app/src/CoreGameLogic/Feature/Spielzug/Dto/TransactionEntry.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/Dto/TransactionEntry.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\CoreGameLogic\Feature\Spielzug\Dto;
+
+use Domain\CoreGameLogic\Feature\Spielzug\ValueObject\PlayerTurn;
+use Domain\Definitions\Card\ValueObject\MoneyAmount;
+
+readonly class TransactionEntry
+{
+    public function __construct(
+        public PlayerTurn $playerTurn,
+        public string $iconClass,
+        public string $assetName,
+        public int $amount,
+        public MoneyAmount $price,
+        public string $type,
+        public int $holdingAfter,
+    ) {
+    }
+}

--- a/app/src/CoreGameLogic/Feature/Spielzug/State/TransactionHistoryState.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/State/TransactionHistoryState.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\CoreGameLogic\Feature\Spielzug\State;
+
+use Domain\CoreGameLogic\EventStore\GameEvents;
+use Domain\CoreGameLogic\Feature\Spielzug\Dto\TransactionEntry;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasBoughtImmobilie;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasBoughtInvestment;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasSoldImmobilie;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasSoldImmobilieToAvoidInsolvenz;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasSoldInvestment;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasSoldInvestmentsAfterInvestmentByAnotherPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasSoldInvestmentsToAvoidInsolvenz;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\SpielzugWasEnded;
+use Domain\CoreGameLogic\Feature\Spielzug\ValueObject\PlayerTurn;
+use Domain\CoreGameLogic\PlayerId;
+use Domain\Definitions\Card\CardFinder;
+use Domain\Definitions\Card\Dto\ImmobilienCardDefinition;
+use Domain\Definitions\Card\ValueObject\MoneyAmount;
+use Domain\Definitions\Investments\ValueObject\InvestmentId;
+
+class TransactionHistoryState
+{
+    private static function getIconClassForInvestmentId(InvestmentId $investmentId): string
+    {
+        return match ($investmentId) {
+            InvestmentId::MERFEDES_PENZ, InvestmentId::BETA_PEAR => 'icon-aktien',
+            InvestmentId::ETF_MSCI_WORLD, InvestmentId::ETF_CLEAN_ENERGY => 'icon-ETF',
+            InvestmentId::BAT_COIN, InvestmentId::MEME_COIN => 'icon-krypto',
+        };
+    }
+
+    /**
+     * @return TransactionEntry[]
+     */
+    public static function getTransactionHistoryForPlayer(GameEvents $gameEvents, PlayerId $playerId): array
+    {
+        $entries = [];
+        $turnCount = 0;
+        /** @var array<string, int> $holdings */
+        $holdings = [];
+
+        foreach ($gameEvents as $event) {
+            if ($event instanceof SpielzugWasEnded && $event->playerId->equals($playerId)) {
+                $turnCount++;
+                continue;
+            }
+
+            $currentTurn = new PlayerTurn($turnCount + 1);
+
+            // Investment buy events
+            if ($event instanceof PlayerHasBoughtInvestment && $event->playerId->equals($playerId)) {
+                $assetName = $event->getInvestmentId()->value;
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) + $event->amount;
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: self::getIconClassForInvestmentId($event->getInvestmentId()),
+                    assetName: $assetName,
+                    amount: $event->amount,
+                    price: $event->price,
+                    type: 'Kauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+
+            // Investment sell events (manual)
+            if ($event instanceof PlayerHasSoldInvestment && $event->playerId->equals($playerId)) {
+                $assetName = $event->getInvestmentId()->value;
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) - $event->amount;
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: self::getIconClassForInvestmentId($event->getInvestmentId()),
+                    assetName: $assetName,
+                    amount: $event->amount,
+                    price: $event->price,
+                    type: 'Verkauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+
+            // Investment sell after another player's purchase
+            if ($event instanceof PlayerHasSoldInvestmentsAfterInvestmentByAnotherPlayer && $event->playerId->equals($playerId)) {
+                $assetName = $event->getInvestmentId()->value;
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) - $event->amount;
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: self::getIconClassForInvestmentId($event->getInvestmentId()),
+                    assetName: $assetName,
+                    amount: $event->amount,
+                    price: $event->price,
+                    type: 'Verkauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+
+            // Investment sell to avoid insolvency
+            if ($event instanceof PlayerHasSoldInvestmentsToAvoidInsolvenz && $event->getPlayerId()->equals($playerId)) {
+                $assetName = $event->getInvestmentId()->value;
+                $amount = $event->getAmount();
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) - $amount;
+                $totalReceived = $event->getResourceChanges($playerId)->guthabenChange;
+                $pricePerUnit = $amount > 0 ? new MoneyAmount($totalReceived->value / $amount) : new MoneyAmount(0);
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: self::getIconClassForInvestmentId($event->getInvestmentId()),
+                    assetName: $assetName,
+                    amount: $amount,
+                    price: $pricePerUnit,
+                    type: 'Verkauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+
+            // Immobilie buy
+            if ($event instanceof PlayerHasBoughtImmobilie && $event->getPlayerId()->equals($playerId)) {
+                $cardDef = CardFinder::getInstance()->getCardById($event->getCardId(), ImmobilienCardDefinition::class);
+                $assetName = 'Immobilie: ' . $cardDef->getTitle();
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) + 1;
+                $price = $event->getResourceChanges($playerId)->guthabenChange->negate();
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: 'icon-immobilien',
+                    assetName: $assetName,
+                    amount: 1,
+                    price: $price,
+                    type: 'Kauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+
+            // Immobilie sell (manual)
+            if ($event instanceof PlayerHasSoldImmobilie && $event->getPlayerId()->equals($playerId)) {
+                $cardDef = CardFinder::getInstance()->getCardById($event->getCardId(), ImmobilienCardDefinition::class);
+                $assetName = 'Immobilie: ' . $cardDef->getTitle();
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) - 1;
+                $price = $event->getResourceChanges($playerId)->guthabenChange;
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: 'icon-immobilien',
+                    assetName: $assetName,
+                    amount: 1,
+                    price: $price,
+                    type: 'Verkauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+
+            // Immobilie sell to avoid insolvency
+            if ($event instanceof PlayerHasSoldImmobilieToAvoidInsolvenz && $event->getPlayerId()->equals($playerId)) {
+                $cardDef = CardFinder::getInstance()->getCardById($event->getCardId(), ImmobilienCardDefinition::class);
+                $assetName = 'Immobilie: ' . $cardDef->getTitle();
+                $holdings[$assetName] = ($holdings[$assetName] ?? 0) - 1;
+                $price = $event->getResourceChanges($playerId)->guthabenChange;
+                $entries[] = new TransactionEntry(
+                    playerTurn: $currentTurn,
+                    iconClass: 'icon-immobilien',
+                    assetName: $assetName,
+                    amount: 1,
+                    price: $price,
+                    type: 'Verkauf',
+                    holdingAfter: $holdings[$assetName],
+                );
+                continue;
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/app/tests/Unit/CoreGameLogic/Feature/Spielzug/State/TransactionHistoryStateTest.php
+++ b/app/tests/Unit/CoreGameLogic/Feature/Spielzug/State/TransactionHistoryStateTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+use Domain\CoreGameLogic\Feature\Spielzug\Command\BuyImmobilieForPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\BuyInvestmentsForPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\DoMinijob;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\DontSellInvestmentsForPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\EndSpielzug;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\SellInvestmentsForPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\Command\SellInvestmentsForPlayerAfterInvestmentByAnotherPlayer;
+use Domain\CoreGameLogic\Feature\Spielzug\State\TransactionHistoryState;
+use Domain\Definitions\Card\Dto\ImmobilienCardDefinition;
+use Domain\Definitions\Card\Dto\ResourceChanges;
+use Domain\Definitions\Card\ValueObject\CardId;
+use Domain\Definitions\Card\ValueObject\ImmobilienType;
+use Domain\Definitions\Card\ValueObject\LebenszielPhaseId;
+use Domain\Definitions\Card\ValueObject\MoneyAmount;
+use Domain\Definitions\Configuration\Configuration;
+use Domain\Definitions\Investments\ValueObject\InvestmentId;
+use Tests\TestCase;
+
+beforeEach(function () {
+    /** @var TestCase $this */
+    $this->setupBasicGame();
+});
+
+describe('TransactionHistoryState::getTransactionHistoryForPlayer', function () {
+    it('returns empty array when no transactions exist', function () {
+        /** @var TestCase $this */
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $history = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+
+        expect($history)->toBeArray()->toBeEmpty();
+    });
+
+    it('records a single investment buy', function () {
+        /** @var TestCase $this */
+        // Player 0 buys stocks
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 10)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $history = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+
+        expect($history)->toHaveCount(1)
+            ->and($history[0]->playerTurn->value)->toBe(1)
+            ->and($history[0]->assetName)->toBe('Merfedes-Penz')
+            ->and($history[0]->type)->toBe('Kauf')
+            ->and($history[0]->amount)->toBe(10)
+            ->and($history[0]->price)->toEqual(new MoneyAmount(Configuration::INITIAL_INVESTMENT_PRICE))
+            ->and($history[0]->holdingAfter)->toBe(10)
+            ->and($history[0]->iconClass)->toBe('icon-aktien');
+    });
+
+    it('records buy and sell with correct holding after', function () {
+        /** @var TestCase $this */
+        // Turn 1: Player 0 buys 10 stocks
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 10)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+
+        // Player 1 does minijob and ends turn
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Turn 2: Player 0 sells 3 stocks
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            SellInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 3)
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $history = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+
+        expect($history)->toHaveCount(2)
+            ->and($history[0]->type)->toBe('Kauf')
+            ->and($history[0]->holdingAfter)->toBe(10)
+            ->and($history[0]->playerTurn->value)->toBe(1)
+            ->and($history[1]->type)->toBe('Verkauf')
+            ->and($history[1]->amount)->toBe(3)
+            ->and($history[1]->holdingAfter)->toBe(7)
+            ->and($history[1]->playerTurn->value)->toBe(2);
+    });
+
+    it('tracks holdings per investment type independently', function () {
+        /** @var TestCase $this */
+        // Turn 1: Player 0 buys Merfedes-Penz
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 10)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+
+        // Player 1 does minijob and ends turn
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Turn 2: Player 0 buys Bat-Coin
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::BAT_COIN, 20)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::BAT_COIN)
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $history = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+
+        expect($history)->toHaveCount(2)
+            ->and($history[0]->assetName)->toBe('Merfedes-Penz')
+            ->and($history[0]->holdingAfter)->toBe(10)
+            ->and($history[1]->assetName)->toBe('Bat-Coin')
+            ->and($history[1]->holdingAfter)->toBe(20);
+    });
+
+    it('maps icon classes correctly for different investment types', function () {
+        /** @var TestCase $this */
+        // Turn 1: Buy Aktie
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 1)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Turn 2: Buy ETF
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::ETF_MSCI_WORLD, 1)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::ETF_MSCI_WORLD)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[1]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Turn 3: Buy Krypto
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::BAT_COIN, 1)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::BAT_COIN)
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $history = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+
+        expect($history)->toHaveCount(3)
+            ->and($history[0]->iconClass)->toBe('icon-aktien')
+            ->and($history[1]->iconClass)->toBe('icon-ETF')
+            ->and($history[2]->iconClass)->toBe('icon-krypto');
+    });
+
+    it('records immobilie buy with correct icon and asset name', function () {
+        /** @var TestCase $this */
+        $cardsForTesting = [
+            new ImmobilienCardDefinition(
+                id: new CardId('immo1'),
+                title: 'Kauf Wohnung',
+                description: 'Eine Wohnung steht zum Verkauf.',
+                phaseId: LebenszielPhaseId::PHASE_1,
+                resourceChanges: new ResourceChanges(
+                    guthabenChange: new MoneyAmount(-20000),
+                ),
+                annualRent: new MoneyAmount(1500),
+                immobilienTyp: ImmobilienType::WOHNUNG
+            ),
+        ];
+        $this->startNewKonjunkturphaseWithCardsOnTop($cardsForTesting);
+
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyImmobilieForPlayer::create($this->players[0], new CardId('immo1'))
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $history = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+
+        expect($history)->toHaveCount(1)
+            ->and($history[0]->assetName)->toContain('Immobilie:')
+            ->and($history[0]->assetName)->toContain('Kauf Wohnung')
+            ->and($history[0]->iconClass)->toBe('icon-immobilien')
+            ->and($history[0]->type)->toBe('Kauf')
+            ->and($history[0]->amount)->toBe(1)
+            ->and($history[0]->price)->toEqual(new MoneyAmount(20000))
+            ->and($history[0]->holdingAfter)->toBe(1);
+    });
+
+    it('only returns transactions for the requested player', function () {
+        /** @var TestCase $this */
+        // Player 0 buys stocks
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 10)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+
+        $historyPlayer0 = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[0]);
+        $historyPlayer1 = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[1]);
+
+        expect($historyPlayer0)->toHaveCount(1)
+            ->and($historyPlayer1)->toBeEmpty();
+    });
+
+    it('records optional sell after another player buys investments', function () {
+        /** @var TestCase $this */
+        // Turn 1: Player 0 does minijob
+        $this->coreGameLogic->handle($this->gameId, DoMinijob::create($this->players[0]));
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+
+        // Turn 1: Player 1 buys stocks so they have some to sell later
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ, 10)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // Turn 2: Player 0 buys stocks — player 1 gets prompted to sell
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 5)
+        );
+
+        // Player 1 sells 3 in response
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            SellInvestmentsForPlayerAfterInvestmentByAnotherPlayer::create(
+                $this->players[1],
+                InvestmentId::MERFEDES_PENZ,
+                3
+            )
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        $historyPlayer1 = TransactionHistoryState::getTransactionHistoryForPlayer($gameEvents, $this->players[1]);
+
+        expect($historyPlayer1)->toHaveCount(2)
+            ->and($historyPlayer1[0]->type)->toBe('Kauf')
+            ->and($historyPlayer1[0]->amount)->toBe(10)
+            ->and($historyPlayer1[0]->holdingAfter)->toBe(10)
+            ->and($historyPlayer1[1]->type)->toBe('Verkauf')
+            ->and($historyPlayer1[1]->amount)->toBe(3)
+            ->and($historyPlayer1[1]->holdingAfter)->toBe(7)
+            ->and($historyPlayer1[1]->iconClass)->toBe('icon-aktien');
+    });
+});


### PR DESCRIPTION
Players often asked to see a history of their transactions. This adds a history to each investment tab. It is added below the important buttons and inputs to avoid a situation where the Player needs to scroll to buy/sell investments.

Fixes: #637

<img width="855" height="536" alt="image" src="https://github.com/user-attachments/assets/2f1c8d39-831a-44fc-827c-43498c37e56f" />