### PR TITLE
feat: prefered group sizes when creating groups

### DIFF
--- a/app/app/Filament/Admin/Resources/CourseResource/Pages/ViewCourse.php
+++ b/app/app/Filament/Admin/Resources/CourseResource/Pages/ViewCourse.php
@@ -16,6 +16,7 @@ use Domain\CoreGameLogic\PlayerId;
 use Filament\Actions\Action;
 use Filament\Actions\ImportAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Database\Eloquent\Collection;
@@ -26,10 +27,75 @@ class ViewCourse extends ViewRecord
     protected static string $resource = CourseResource::class;
 
     /**
+     * @return int[] Array of group sizes (e.g. [4, 4, 3] for 11 players preferring 4er groups)
+     */
+    private static function calculateGroupSizes(int $n, int $preferGroupsOf): array
+    {
+        if ($n < 2) {
+            return [];
+        }
+        if ($n <= 4) {
+            return [$n];
+        }
+        if ($n === 5) {
+            return [3, 2];
+        }
+
+        if ($preferGroupsOf === 3) {
+            return self::calculateGroupSizesPrefer3($n);
+        }
+
+        return self::calculateGroupSizesPrefer4($n);
+    }
+
+    /**
+     * @return int[]
+     */
+    private static function calculateGroupSizesPrefer4(int $n): array
+    {
+        $remainder = $n % 4;
+
+        if ($remainder === 0) {
+            return array_fill(0, intdiv($n, 4), 4);
+        }
+
+        if ($remainder === 3) {
+            return [...array_fill(0, intdiv($n, 4), 4), 3];
+        }
+
+        if ($remainder === 2) {
+            return [...array_fill(0, intdiv($n - 6, 4), 4), 3, 3];
+        }
+
+        // remainder === 1: subtract 9 (three 3er groups), rest fills with 4er
+        return [...array_fill(0, intdiv($n - 9, 4), 4), 3, 3, 3];
+    }
+
+    /**
+     * @return int[]
+     */
+    private static function calculateGroupSizesPrefer3(int $n): array
+    {
+        $remainder = $n % 3;
+
+        if ($remainder === 0) {
+            return array_fill(0, intdiv($n, 3), 3);
+        }
+
+        if ($remainder === 1) {
+            // one 4er group, rest 3er
+            return [...array_fill(0, intdiv($n - 4, 3), 3), 4];
+        }
+
+        // remainder === 2: two 4er groups, rest 3er
+        return [...array_fill(0, intdiv($n - 8, 3), 3), 4, 4];
+    }
+
+    /**
      * @param Collection<int, Player> $playersCollection
      * @return array<array<Player>>
      */
-    private static function createRandomGameGroups(Collection $playersCollection): array
+    private static function createRandomGameGroups(Collection $playersCollection, int $preferGroupsOf = 4): array
     {
         $allPlayers = [];
 
@@ -37,39 +103,30 @@ class ViewCourse extends ViewRecord
             $allPlayers[] = $player;
         }
 
-        // We need at least two players
-        if (count($allPlayers) < 2) {
+        $groupSizes = self::calculateGroupSizes(count($allPlayers), $preferGroupsOf);
+
+        if ($groupSizes === []) {
             return [];
         }
 
-        // we want random groups, so we shuffle all players before slicing the array into groups
         shuffle($allPlayers);
 
         $gameGroups = [];
-
-        /**
-         * WHY:
-         * We need at least 2 players in a game. If we fill all games with four players we may end up
-         * with one group that only has 1 player. That is the case when playerCount % 4 === 1. In that
-         * case we can simply create one group with 2 players and one group with 3 players. The remaining
-         * players can be put in full groups.
-         */
-        if (count($allPlayers) > 4 && count($allPlayers) % 4 === 1) {
-            $gameGroups[] = array_slice($allPlayers, 0, 3);
-            $gameGroups[] = array_slice($allPlayers, 3, 2);
-            $allPlayers = array_slice($allPlayers, 5);
-        }
-
-        /**
-         * Fill the remaining games with up to 4 players (unless there are less than 4 left)
-         */
-        $playersPerGame = 4;
-        $numberOfGames = (int) ceil(count($allPlayers) / $playersPerGame);
-        for ($i = 0; $i < $numberOfGames; $i++) {
-            $gameGroups[] = array_slice($allPlayers, $i * $playersPerGame, $playersPerGame);
+        $offset = 0;
+        foreach ($groupSizes as $size) {
+            $gameGroups[] = array_slice($allPlayers, $offset, $size);
+            $offset += $size;
         }
 
         return $gameGroups;
+    }
+
+    /**
+     * @return int[]
+     */
+    public static function calculateGroupSizesForTesting(int $n, int $preferGroupsOf): array
+    {
+        return self::calculateGroupSizes($n, $preferGroupsOf);
     }
 
     /**
@@ -78,9 +135,9 @@ class ViewCourse extends ViewRecord
      * @param Collection<int, Player> $playersCollection
      * @return array<array<Player>>
      */
-    public static function createRandomGameGroupsForTesting(Collection $playersCollection): array
+    public static function createRandomGameGroupsForTesting(Collection $playersCollection, int $preferGroupsOf = 4): array
     {
-        return self::createRandomGameGroups($playersCollection);
+        return self::createRandomGameGroups($playersCollection, $preferGroupsOf);
     }
 
     protected function getHeaderActions(): array
@@ -94,7 +151,17 @@ class ViewCourse extends ViewRecord
                     'course' => $this->record
                 ]),
             Action::make('Spiele erstellen')
-                ->action(function (ForCoreGameLogic $coreGameLogic) {
+                ->form([
+                    Select::make('preferGroupsOf')
+                        ->label('Gruppengröße bevorzugen')
+                        ->options([
+                            4 => 'Bevorzugt 4er-Gruppen',
+                            3 => 'Bevorzugt 3er-Gruppen',
+                        ])
+                        ->default(4)
+                        ->required(),
+                ])
+                ->action(function (array $data, ForCoreGameLogic $coreGameLogic) {
 
                     /** @var Course $course */
                     $course = $this->record;
@@ -102,7 +169,7 @@ class ViewCourse extends ViewRecord
                     $panel = Filament::getCurrentPanel();
                     $user = $panel?->auth()->user();
 
-                    $gameGroups = self::createRandomGameGroups($course->players);
+                    $gameGroups = self::createRandomGameGroups($course->players, (int) $data['preferGroupsOf']);
 
                     if (count($gameGroups) === 0) {
                         Notification::make()

--- a/app/tests/Unit/App/Filament/Admin/Resources/CourseResource/Pages/ViewCourseTest.php
+++ b/app/tests/Unit/App/Filament/Admin/Resources/CourseResource/Pages/ViewCourseTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use App\Filament\Admin\Resources\CourseResource\Pages\ViewCourse;
-use App\Models\Player;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Tests\TestCase;
@@ -12,88 +11,122 @@ beforeEach(function () {
     /** @var TestCase $this */
 });
 
-describe('create random game groups', function () {
+describe('calculateGroupSizes', function () {
+    describe('prefer 4er groups', function () {
+        it('returns empty for less than 2 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(0, 4))->toBe([])
+                ->and(ViewCourse::calculateGroupSizesForTesting(1, 4))->toBe([]);
+        });
+
+        it('returns correct sizes for small groups', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(2, 4))->toBe([2])
+                ->and(ViewCourse::calculateGroupSizesForTesting(3, 4))->toBe([3])
+                ->and(ViewCourse::calculateGroupSizesForTesting(4, 4))->toBe([4]);
+        });
+
+        it('returns [3, 2] for 5 players (only case with a 2er group)', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(5, 4))->toBe([3, 2]);
+        });
+
+        it('returns [3, 3] for 6 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(6, 4))->toBe([3, 3]);
+        });
+
+        it('returns [4, 3] for 7 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(7, 4))->toBe([4, 3]);
+        });
+
+        it('returns [4, 4] for 8 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(8, 4))->toBe([4, 4]);
+        });
+
+        it('returns [3, 3, 3] for 9 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(9, 4))->toBe([3, 3, 3]);
+        });
+
+        it('returns [4, 3, 3] for 10 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(10, 4))->toBe([4, 3, 3]);
+        });
+
+        it('returns all 4er for multiples of 4', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(12, 4))->toBe([4, 4, 4])
+                ->and(ViewCourse::calculateGroupSizesForTesting(16, 4))->toBe([4, 4, 4, 4])
+                ->and(ViewCourse::calculateGroupSizesForTesting(20, 4))->toBe([4, 4, 4, 4, 4]);
+        });
+
+        it('never creates 2er groups except for n=5', function () {
+            for ($n = 6; $n <= 30; $n++) {
+                $sizes = ViewCourse::calculateGroupSizesForTesting($n, 4);
+                foreach ($sizes as $size) {
+                    expect($size)->toBeGreaterThanOrEqual(3, "n=$n produced a group of size $size");
+                }
+                expect(array_sum($sizes))->toBe($n, "n=$n: sum of group sizes doesn't match");
+            }
+        });
+    });
+
+    describe('prefer 3er groups', function () {
+        it('returns empty for less than 2 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(0, 3))->toBe([])
+                ->and(ViewCourse::calculateGroupSizesForTesting(1, 3))->toBe([]);
+        });
+
+        it('returns correct sizes for small groups', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(2, 3))->toBe([2])
+                ->and(ViewCourse::calculateGroupSizesForTesting(3, 3))->toBe([3])
+                ->and(ViewCourse::calculateGroupSizesForTesting(4, 3))->toBe([4]);
+        });
+
+        it('returns [3, 2] for 5 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(5, 3))->toBe([3, 2]);
+        });
+
+        it('returns [3, 3] for 6 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(6, 3))->toBe([3, 3]);
+        });
+
+        it('returns [3, 4] for 7 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(7, 3))->toBe([3, 4]);
+        });
+
+        it('returns [4, 4] for 8 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(8, 3))->toBe([4, 4]);
+        });
+
+        it('returns all 3er for multiples of 3', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(9, 3))->toBe([3, 3, 3])
+                ->and(ViewCourse::calculateGroupSizesForTesting(12, 3))->toBe([3, 3, 3, 3])
+                ->and(ViewCourse::calculateGroupSizesForTesting(15, 3))->toBe([3, 3, 3, 3, 3]);
+        });
+
+        it('returns [3, 3, 4] for 10 players', function () {
+            expect(ViewCourse::calculateGroupSizesForTesting(10, 3))->toBe([3, 3, 4]);
+        });
+
+        it('never creates 2er groups except for n=5', function () {
+            for ($n = 6; $n <= 30; $n++) {
+                $sizes = ViewCourse::calculateGroupSizesForTesting($n, 3);
+                foreach ($sizes as $size) {
+                    expect($size)->toBeGreaterThanOrEqual(3, "n=$n produced a group of size $size");
+                }
+                expect(array_sum($sizes))->toBe($n, "n=$n: sum of group sizes doesn't match");
+            }
+        });
+    });
+});
+
+describe('createRandomGameGroups', function () {
     it('returns an empty array if there are not enough players', function () {
-        /** @var testcase $this */
-        // test with one player
-        $playerGroups = new Collection([
-            User::factory()->count(1)->make(),
-        ]);
+        $playerGroups = new Collection([User::factory()->count(1)->make()]);
         $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
         expect($actualGameGroups)->toBe([]);
 
-        // test with no players
         $playerGroups = new Collection([]);
         $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
         expect($actualGameGroups)->toBe([]);
     });
 
-    it('returns an array with one group of two players for two players', function () {
-        /** @var testcase $this */
-
-        [$player1, $player2] = User::factory()->count(2)->make();
-        $playerGroups = new Collection([
-            $player1,
-            $player2,
-        ]);
-        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
-        expect(count($actualGameGroups))->toBe(1, "actualGameGroups should containt 1 game group")
-            ->and(count($actualGameGroups[0]))->toBe(2, "Game group should contain 2 players");
-        $actualPlayerIds = array_map(fn ($player) => $player->name, $actualGameGroups[0]);
-        expect($actualPlayerIds)->toContainEqual($player1->name, $player2->name);
-    });
-
-    it('returns one group with 2 and one with 3 player, when 5 players are in a course', function () {
-        /** @var testcase $this */
-        $players = User::factory()->count(5)->make();
-        $playerGroups = new Collection($players);
-
-        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
-        expect(count($actualGameGroups))->toBe(2, "actualGameGroups should containt 2 game groups");
-
-        $actualGroupSizes = array_map(fn ($group) => count($group), $actualGameGroups);
-        expect($actualGroupSizes)->toContain(2, 3);
-    });
-
-    it('works for exactly 4 players in a course', function () {
-        /** @var testcase $this */
-        $players = User::factory()->count(4)->make();
-        $playerGroups = new Collection($players);
-
-        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
-        expect(count($actualGameGroups))->toBe(1, "actualGameGroups should containt 4 game groups");
-
-        $actualGroupSizes = array_map(fn ($group) => count($group), $actualGameGroups);
-        expect($actualGroupSizes)->toEqual([4]);
-    });
-
-    it('works for course numbers divisible by 4', function () {
-        /** @var testcase $this */
-        $players = User::factory()->count(16)->make();
-        $playerGroups = new Collection($players);
-
-        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
-        expect(count($actualGameGroups))->toBe(4, "actualGameGroups should containt 4 game groups");
-
-        $actualGroupSizes = array_map(fn ($group) => count($group), $actualGameGroups);
-        expect($actualGroupSizes)->toEqual([4, 4, 4, 4]);
-    });
-
-    it('works for course numbers divisible by 4 with a rest of 1', function () {
-        /** @var testcase $this */
-        $players = User::factory()->count(17)->make();
-        $playerGroups = new Collection($players);
-
-        $actualGameGroups = ViewCourse::createRandomGameGroupsForTesting($playerGroups);
-        expect(count($actualGameGroups))->toBe(5, "actualGameGroups should containt 4 game groups");
-
-        $actualGroupSizes = array_map(fn ($group) => count($group), $actualGameGroups);
-        expect($actualGroupSizes)->toEqual([3, 2, 4, 4, 4]);
-    });
-
-
     it('assigns every player to a game', function () {
-        /** @var testcase $this */
         $players = User::factory()->count(17)->make();
         $expectedPlayersInGroups = [];
         foreach ($players as $player) {
@@ -106,10 +139,25 @@ describe('create random game groups', function () {
         foreach ($actualGameGroups as $group) {
             foreach ($group as $player) {
                 $actualPlayersInGroups[] = $player->name;
-            };
-        };
+            }
+        }
 
         expect($actualPlayersInGroups)->toHaveCount(17)
             ->and($actualPlayersInGroups)->toContain(...$expectedPlayersInGroups);
+    });
+
+    it('respects preferGroupsOf parameter', function () {
+        $players = User::factory()->count(12)->make();
+        $playerGroups = new Collection($players);
+
+        $groupsPrefer4 = ViewCourse::createRandomGameGroupsForTesting($playerGroups, 4);
+        $sizesPrefer4 = array_map(fn ($group) => count($group), $groupsPrefer4);
+        sort($sizesPrefer4);
+        expect($sizesPrefer4)->toBe([4, 4, 4]);
+
+        $groupsPrefer3 = ViewCourse::createRandomGameGroupsForTesting($playerGroups, 3);
+        $sizesPrefer3 = array_map(fn ($group) => count($group), $groupsPrefer3);
+        sort($sizesPrefer3);
+        expect($sizesPrefer3)->toBe([3, 3, 3, 3]);
     });
 });


### PR DESCRIPTION
Allows the admins to select a prefered group size (3 or 4) when creating the random groups. This tries to prevent groups of just 2 players and use mostly the prefered group size.