### PR TITLE
fix: set min age for packages to reduce supply chain attack risk

### DIFF
--- a/app/.yarnrc.yml
+++ b/app/.yarnrc.yml
@@ -1,3 +1,6 @@
 nodeLinker: node-modules
 # use .yarn/cache folder instead of global cache (https://yarnpkg.com/features/caching)
 enableGlobalCache: false
+
+# Block installation of packages published less than 14 days ago to reduce supply chain attack exposure
+npmMinimalAgeGate: "14d"


### PR DESCRIPTION
- [x] yarn > 4.10 => in mise.toml: 4.12 ✅
- [x] `npmMinimalAgeGate: "14d"` in yarnrc.yml