### PR TITLE
fix: turn cannot end after selling an investment when a different type was last bought

### DIFF
--- a/app/src/CoreGameLogic/Feature/Spielzug/Aktion/Validator/HasAnotherPlayerInvestedThisTurnValidator.php
+++ b/app/src/CoreGameLogic/Feature/Spielzug/Aktion/Validator/HasAnotherPlayerInvestedThisTurnValidator.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Domain\CoreGameLogic\Feature\Spielzug\Aktion\Validator;
 
 use Domain\CoreGameLogic\EventStore\GameEvents;
-use Domain\CoreGameLogic\Feature\Initialization\State\GamePhaseState;
+use Domain\CoreGameLogic\Feature\Initialization\Event\GameWasStarted;
 use Domain\CoreGameLogic\Feature\Spielzug\Dto\AktionValidationResult;
 use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasBoughtInvestment;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\PlayerHasSoldInvestment;
+use Domain\CoreGameLogic\Feature\Spielzug\Event\SpielzugWasEnded;
 use Domain\Definitions\Investments\ValueObject\InvestmentId;
 use Domain\CoreGameLogic\PlayerId;
 
@@ -27,10 +29,16 @@ final class HasAnotherPlayerInvestedThisTurnValidator extends AbstractValidator
 
     public function validate(GameEvents $gameEvents, PlayerId $playerId): AktionValidationResult
     {
-        $anotherPlayerHasInvestedThisTurn = GamePhaseState::anotherPlayerHasInvestedThisTurn($gameEvents, $playerId);
-        $investmentsBought = $gameEvents->findLastOrNull(PlayerHasBoughtInvestment::class)?->getInvestmentId();
+        $eventsThisTurn = $gameEvents->findAllAfterLastOfTypeOrNull(SpielzugWasEnded::class)
+            ?? $gameEvents->findAllAfterLastOfType(GameWasStarted::class);
 
-        if (!$anotherPlayerHasInvestedThisTurn || $investmentsBought !== $this->investmentId) {
+        $investmentEventThisTurn = $eventsThisTurn->findLastOrNullWhere(
+            fn ($event) => ($event instanceof PlayerHasBoughtInvestment || $event instanceof PlayerHasSoldInvestment)
+                && !$event->getPlayerId()->equals($playerId)
+                && $event->getInvestmentId() === $this->investmentId
+        );
+
+        if ($investmentEventThisTurn === null) {
             return new AktionValidationResult(
                 canExecute: false,
                 reason: 'Ein anderer Spieler muss Investitionen der gleichen Art gekauft oder verkauft haben, bevor du welche verkaufen kannst.',

--- a/app/tests/Unit/CoreGameLogic/Feature/Spielzug/SellInvestmentsTest.php
+++ b/app/tests/Unit/CoreGameLogic/Feature/Spielzug/SellInvestmentsTest.php
@@ -132,6 +132,52 @@ describe('handleSellInvestmentsForPlayer', function () {
             )
         );
     })->throws(\RuntimeException::class, 'Du hast nicht genug Investitionen vom Typ Merfedes-Penz zum Verkaufen.', 1752753850);
+
+    it('allows other players to respond to the investments modal when the active player sells a different investment type than was last globally bought', function () {
+        // player 0 buys MERFEDES_PENZ on turn 1
+        /** @var TestCase $this */
+        $this->handle(new StartSpielzug($this->players[0]));
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 100)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+
+        // player 1 buys BAT_COIN on turn 1 — now the globally last PlayerHasBoughtInvestment is BAT_COIN
+        $this->handle(new StartSpielzug($this->players[1]));
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            BuyInvestmentsForPlayer::create($this->players[1], InvestmentId::BAT_COIN, 100)
+        );
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[0], InvestmentId::BAT_COIN)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[1]));
+
+        // player 0 sells MERFEDES_PENZ on turn 2
+        $this->handle(new StartSpielzug($this->players[0]));
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            SellInvestmentsForPlayer::create($this->players[0], InvestmentId::MERFEDES_PENZ, 100)
+        );
+
+        $gameEvents = $this->coreGameLogic->getGameEvents($this->gameId);
+        expect(PlayerState::getAmountOfAllInvestmentsOfTypeForPlayer($gameEvents, $this->players[0], InvestmentId::MERFEDES_PENZ))->toEqual(0);
+
+        // player 1 must be able to respond "don't sell" for MERFEDES_PENZ
+        // BUG: this failed because HasAnotherPlayerInvestedThisTurnValidator used the globally
+        // last PlayerHasBoughtInvestment (BAT_COIN), which does not match MERFEDES_PENZ
+        $this->coreGameLogic->handle(
+            $this->gameId,
+            DontSellInvestmentsForPlayer::create($this->players[1], InvestmentId::MERFEDES_PENZ)
+        );
+        $this->coreGameLogic->handle($this->gameId, new EndSpielzug($this->players[0]));
+    });
 });
 
 describe('handleSellInvestmentsForPlayerAfterPurchaseByAnotherPlayer', function () {


### PR DESCRIPTION
HasAnotherPlayerInvestedThisTurnValidator looked up the investment type from the globally last PlayerHasBoughtInvestment event across all turns. When a player sold investment A while the last globally bought investment was B, other players could not respond to the sell modal, leaving NoPlayerNeedsToSellInvestmentsValidator permanently blocking EndSpielzug.

Fix by scoping the lookup to buy/sell events of the matching investment type within the current turn only.