### PR TITLE
fix: euro sign alignment

### DIFF
--- a/app/app/Livewire/Traits/HasMoneySheet.php
+++ b/app/app/Livewire/Traits/HasMoneySheet.php
@@ -42,6 +42,9 @@ trait HasMoneySheet
     public MoneySheetInsurancesForm $moneySheetInsurancesForm;
     public TakeOutALoanForm $takeOutALoanForm;
 
+    public ?float $lebenshaltungskostenFine = null;
+    public ?float $steuernUndAbgabenFine = null;
+
     public bool $moneySheetIsVisible = false;
     public bool $editIncomeIsVisible = false;
     public bool $editExpensesIsVisible = false;
@@ -203,16 +206,14 @@ trait HasMoneySheet
         $updatedEvents = $this->coreGameLogic->getGameEvents($this->gameId);
         $resultOfLastInput = MoneySheetState::getResultOfLastLebenshaltungskostenInput($updatedEvents, $this->myself);
 
-        if (!$resultOfLastInput->wasSuccessful && $resultOfLastInput->fine->value > 0) {
-            $this->moneySheetLebenshaltungskostenForm->addError(
-                'lebenshaltungskosten',
-                "Du hast einen falschen Wert für die Lebenshaltungskosten eingegeben. Dir wurden {$resultOfLastInput->fine->value} € abgezogen. Wir haben den Wert für dich korrigiert."
-            );
-        } elseif (!$resultOfLastInput->wasSuccessful) {
+        if (!$resultOfLastInput->wasSuccessful) {
+            $this->lebenshaltungskostenFine = $resultOfLastInput->fine->value > 0 ? $resultOfLastInput->fine->value : null;
             $this->moneySheetLebenshaltungskostenForm->addError(
                 'lebenshaltungskosten',
                 "Du hast einen falschen Wert für die Lebenshaltungskosten eingegeben."
             );
+        } else {
+            $this->lebenshaltungskostenFine = null;
         }
 
         $this->initializeLivingCostsForm();
@@ -230,16 +231,14 @@ trait HasMoneySheet
         $updatedEvents = $this->coreGameLogic->getGameEvents($this->gameId);
         $resultOfLastInput = MoneySheetState::getResultOfLastSteuernUndAbgabenInput($updatedEvents, $this->myself);
 
-        if (!$resultOfLastInput->wasSuccessful && $resultOfLastInput->fine->value > 0) {
-            $this->moneySheetSteuernUndAbgabenForm->addError(
-                'steuernUndAbgaben',
-                "Du hast einen falschen Wert für die Steuern und Abgaben eingegeben. Dir wurden {$resultOfLastInput->fine->value} € abgezogen. Wir haben den Wert für dich korrigiert."
-            );
-        } elseif (!$resultOfLastInput->wasSuccessful) {
+        if (!$resultOfLastInput->wasSuccessful) {
+            $this->steuernUndAbgabenFine = $resultOfLastInput->fine->value > 0 ? $resultOfLastInput->fine->value : null;
             $this->moneySheetSteuernUndAbgabenForm->addError(
                 'steuernUndAbgaben',
                 "Du hast einen falschen Wert für die Steuern und Abgaben eingegeben."
             );
+        } else {
+            $this->steuernUndAbgabenFine = null;
         }
 
         $this->initializeTaxesForm();

--- a/app/resources/css/app/button.css
+++ b/app/resources/css/app/button.css
@@ -35,6 +35,13 @@ button {
     }
 }
 
+/* The global .icon-euro offset in .text--currency corrects for the glyph sitting low
+   in its em square. Inside a button the button's own flex centering already handles
+   vertical alignment, so the offset overcorrects and must be reset. */
+.button--type-secondary .text--currency .icon-euro {
+    top: 0;
+}
+
 .button__suffix {
     display: flex;
     min-height: var(--button-height);

--- a/app/resources/css/typography.css
+++ b/app/resources/css/typography.css
@@ -69,6 +69,12 @@ i {
     i {
         font-size: .8em;
     }
+
+    .icon-euro {
+        position: relative;
+        top: -0.07em;
+        color: inherit;
+    }
 }
 
 .font-size--sm {

--- a/app/resources/views/components/dynamic-money-amount.blade.php
+++ b/app/resources/views/components/dynamic-money-amount.blade.php
@@ -1,0 +1,5 @@
+@props(['expression'])
+<span class="text--currency">
+    <span x-text="new Intl.NumberFormat('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format({!! $expression !!})"></span>
+    <i aria-hidden="true" class="icon-euro"></i><span class="sr-only">€</span>
+</span>

--- a/app/resources/views/components/gameboard/cardPile/card.css
+++ b/app/resources/views/components/gameboard/cardPile/card.css
@@ -150,4 +150,10 @@
     .card__effects {
         margin-right: auto;
     }
+
+    /* Outer flex centering already handles vertical alignment — reset the global
+       .icon-euro glyph offset that would otherwise push the icon too high. */
+    .text--currency .icon-euro {
+        top: 0;
+    }
 }

--- a/app/resources/views/components/gameboard/investitionen/investitionen-buy-form.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/investitionen-buy-form.blade.php
@@ -26,8 +26,7 @@
     </div>
     <div class="investitionen-form__sum">
         <strong>Summe Kauf</strong>
-        <span
-            x-text="new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format($wire.buyInvestmentsForm.amount * $wire.buyInvestmentsForm.sharePrice)"></span>
+        <x-dynamic-money-amount expression="$wire.buyInvestmentsForm.amount * $wire.buyInvestmentsForm.sharePrice" />
     </div>
     <x-form.submit disabled wire:dirty.remove.attr="disabled">
         {{ $buyButtonLabel }}

--- a/app/resources/views/components/gameboard/investitionen/investitionen-sell-form.blade.php
+++ b/app/resources/views/components/gameboard/investitionen/investitionen-sell-form.blade.php
@@ -28,8 +28,7 @@
         </div>
         <div class="investitionen-form__sum">
             <strong>Summe Verkauf</strong>
-            <span
-                x-text="new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format($wire.sellInvestmentsForm.amount * $wire.sellInvestmentsForm.sharePrice)"></span>
+            <x-dynamic-money-amount expression="$wire.sellInvestmentsForm.amount * $wire.sellInvestmentsForm.sharePrice" />
         </div>
         <x-form.submit disabled wire:dirty.remove.attr="disabled">
             {{ $sellButtonLabel }}

--- a/app/resources/views/components/gameboard/investitionen/transactionHistory.css
+++ b/app/resources/views/components/gameboard/investitionen/transactionHistory.css
@@ -38,4 +38,10 @@
     td {
         border-bottom: 1px solid var(--color-grey);
     }
+
+    /* Table cells use vertical-align: middle by default, so the global .icon-euro
+       offset overcorrects — reset it here as in .button--type-secondary. */
+    td .text--currency .icon-euro {
+        top: 0;
+    }
 }

--- a/app/resources/views/components/gameboard/moneySheet/expenses/insurances.css
+++ b/app/resources/views/components/gameboard/moneySheet/expenses/insurances.css
@@ -43,6 +43,12 @@
         min-width: 150px;
         justify-content: center;
         height: var(--button-height);
+
+        /* Outer flex centering already handles vertical alignment — reset the global
+           .icon-euro glyph offset that would otherwise push the icon too high. */
+        .icon-euro {
+            top: 0;
+        }
         padding-inline: var(--spacing-100);
 
         background: var(--color-semi-transparent);

--- a/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-living-costs.blade.php
+++ b/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-living-costs.blade.php
@@ -1,4 +1,5 @@
 @use('Domain\CoreGameLogic\Feature\Spielzug\State\PlayerState')
+@use('Domain\Definitions\Card\ValueObject\MoneyAmount')
 
 @props([
     'moneySheet' => null,
@@ -53,7 +54,14 @@
     </div>
 
     <div class="tabs__lower-content taxes__actions">
-        @error('moneySheetLebenshaltungskostenForm.lebenshaltungskosten') <span class="form-error badge-with-background">{{ $message }}</span> @enderror
+        @error('moneySheetLebenshaltungskostenForm.lebenshaltungskosten')
+            <span class="form-error badge-with-background">
+                {{ $message }}
+                @if ($this->lebenshaltungskostenFine)
+                    Dir wurden <x-money-amount :value="new MoneyAmount($this->lebenshaltungskostenFine)" /> abgezogen. Wir haben den Wert für dich korrigiert.
+                @endif
+            </span>
+        @enderror
         <x-form.submit :disabled="$this->moneySheetLebenshaltungskostenForm->isLebenshaltungskostenInputDisabled">Änderungen speichern</x-form.submit>
     </div>
 </form>

--- a/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-taxes.blade.php
+++ b/app/resources/views/components/gameboard/moneySheet/expenses/money-sheet-taxes.blade.php
@@ -1,3 +1,5 @@
+@use('Domain\Definitions\Card\ValueObject\MoneyAmount')
+
 @props([
     'moneySheet' => null,
 ])
@@ -31,7 +33,14 @@
         </div>
     </div>
     <div class="tabs__lower-content taxes__actions">
-        @error('moneySheetSteuernUndAbgabenForm.steuernUndAbgaben') <span class="form-error badge-with-background">{{ $message }}</span> @enderror
+        @error('moneySheetSteuernUndAbgabenForm.steuernUndAbgaben')
+            <span class="form-error badge-with-background">
+                {{ $message }}
+                @if ($this->steuernUndAbgabenFine)
+                    Dir wurden <x-money-amount :value="new MoneyAmount($this->steuernUndAbgabenFine)" /> abgezogen. Wir haben den Wert für dich korrigiert.
+                @endif
+            </span>
+        @enderror
         <x-form.submit :disabled="$this->moneySheetSteuernUndAbgabenForm->isSteuernUndAbgabenInputDisabled">Änderungen speichern</x-form.submit>
     </div>
 </form>

--- a/app/resources/views/components/gameboard/moneySheet/money-sheet.blade.php
+++ b/app/resources/views/components/gameboard/moneySheet/money-sheet.blade.php
@@ -1,6 +1,7 @@
 @use('Domain\CoreGameLogic\Feature\Spielzug\State\PlayerState')
 @use('Domain\CoreGameLogic\Feature\MoneySheet\State\MoneySheetState')
 @use('Domain\Definitions\Configuration\Configuration')
+@use('Domain\Definitions\Card\ValueObject\MoneyAmount')
 
 @props(['moneySheet' => null])
 
@@ -107,7 +108,7 @@
                     <td>
                         <p>
                             Bei allen Einnahmen und Ausgaben, die Du selbst berechnen musst, hast Du immer zwei Versuche. <br />
-                            <strong>Bei dem dritten Fehlversuch hilft Dir das Spiel. Dir werden jedoch {{ Configuration::FINE_VALUE }} € abgezogen.</strong>
+                            <strong>Bei dem dritten Fehlversuch hilft Dir das Spiel. Dir werden jedoch <x-money-amount :value="new MoneyAmount(Configuration::FINE_VALUE)" /> abgezogen.</strong>
                         </p>
                     </td>
                 </tr>

--- a/app/resources/views/components/gameboard/moneySheet/take-out-loan-modal.blade.php
+++ b/app/resources/views/components/gameboard/moneySheet/take-out-loan-modal.blade.php
@@ -69,8 +69,7 @@
 
         <div class="form-group take-out-loan__sum">
             <strong>Rückzahlungssumme</strong>
-            <span
-                x-text="new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format($wire.takeOutALoanForm.loanAmount * (1 + $wire.takeOutALoanForm.zinssatz / $wire.takeOutALoanForm.repaymentPeriod))"></span>
+            <x-dynamic-money-amount expression="$wire.takeOutALoanForm.loanAmount * (1 + $wire.takeOutALoanForm.zinssatz / $wire.takeOutALoanForm.repaymentPeriod)" />
             <p>
                 Rückzahlungssumme = <br />
                 <strong>Kreditsumme * (1 + Zinssatz / {{ Configuration::REPAYMENT_PERIOD }}).</strong><br />
@@ -80,8 +79,7 @@
 
         <div class="form-group take-out-loan__repayment">
             <strong>Rückzahlung pro Runde</strong>
-            <span
-                x-text="new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format($wire.takeOutALoanForm.loanAmount * (1 + $wire.takeOutALoanForm.zinssatz / $wire.takeOutALoanForm.repaymentPeriod) /  $wire.takeOutALoanForm.repaymentPeriod)"></span>
+            <x-dynamic-money-amount expression="$wire.takeOutALoanForm.loanAmount * (1 + $wire.takeOutALoanForm.zinssatz / $wire.takeOutALoanForm.repaymentPeriod) / $wire.takeOutALoanForm.repaymentPeriod" />
             <p>
                 Der Kredit wird innerhalb von <strong>{{ Configuration::REPAYMENT_PERIOD }}</strong> Jahren abbezahlt!
             </p>

--- a/app/resources/views/components/gameboard/moneySheet/takeOutLoan.css
+++ b/app/resources/views/components/gameboard/moneySheet/takeOutLoan.css
@@ -94,7 +94,7 @@
 
 .take-out-loan__sum,
 .take-out-loan__repayment {
-    span {
+    > span {
         display: inline-flex;
         align-items: center;
         width: 100%;

--- a/app/resources/views/components/gameboard/resourceChanges/resourceChanges.css
+++ b/app/resources/views/components/gameboard/resourceChanges/resourceChanges.css
@@ -36,4 +36,10 @@
     i.text--danger, i.text--success {
         font-size: var(--font-size-base);
     }
+
+    /* Outer flex centering already handles vertical alignment — reset the global
+       .icon-euro glyph offset that would otherwise push the icon too high. */
+    .text--currency .icon-euro {
+        top: 0;
+    }
 }


### PR DESCRIPTION
The alignment for the euro sign item was of -> it was slightly below the text.
Override the position manually just for the euro sign. This may break on very large fonts