### PR TITLE
fix: Konjunkturphasenwechsel screen on small devices

### DIFF
--- a/app/resources/views/livewire/screens/konjunkturphase-start.blade.php
+++ b/app/resources/views/livewire/screens/konjunkturphase-start.blade.php
@@ -4,6 +4,24 @@
 
 {{-- !!! Livewire components MUST have a single root element !!! --}}
 <div class="konjunkturphase-start">
+    <div class="konjunkturphase-start__actions">
+        <div></div>
+
+        @if ($currentPage >= 1)
+            <button wire:click="startKonjunkturphaseForPlayer()"
+                    type="button"
+                    class="button button--type-borderless">
+                Weiter
+            </button>
+        @else
+            <button wire:click="nextKonjunkturphaseStartScreenPage()"
+                    type="button"
+                    class="button button--type-borderless">
+                Weiter
+            </button>
+        @endif
+    </div>
+
     <div class="konjunkturphase-start__content">
         @if ($currentPage === 0)
             <div class="konjunkturphase-start__info">
@@ -72,22 +90,4 @@
             </div>
         @endif
     </div>
-
-    <footer class="konjunkturphase-start__actions">
-        <div></div>
-
-        @if ($currentPage >= 1)
-            <button wire:click="startKonjunkturphaseForPlayer()"
-                    type="button"
-                    class="button button--type-borderless">
-                Weiter
-            </button>
-        @else
-            <button wire:click="nextKonjunkturphaseStartScreenPage()"
-                    type="button"
-                    class="button button--type-borderless">
-                Weiter
-            </button>
-        @endif
-    </footer>
 </div>

--- a/app/resources/views/livewire/screens/konjunkturphaseStart.css
+++ b/app/resources/views/livewire/screens/konjunkturphaseStart.css
@@ -1,18 +1,19 @@
-.konjunkturphase-start {
-    height: 100vh;
-    display: grid;
-    grid-template-areas:
-        "content"
-        "actions";
-    grid-template-rows: auto 50px;
+.konjunkturphase-start__actions {
+    position: sticky;
+    top: 0;
+    z-index: var(--z-index-footer);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 50px;
+    border-bottom: 1px solid var(--color-primary);
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(8px);
 }
 
 .konjunkturphase-start__content {
-    grid-area: content;
     padding: 20px;
-    height: 100%;
     width: 100%;
-    overflow-y: scroll;
 }
 
 .konjunkturphase-start__info {
@@ -20,7 +21,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    min-height: calc(100dvh - 50px);
 
     h1 {
         margin-bottom: var(--spacing-100);
@@ -37,17 +38,6 @@
     max-width: 100%;
     margin-top: var(--spacing-200);
     border-radius: 10px;
-}
-
-.konjunkturphase-start__actions {
-    grid-area: actions;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-top: 1px solid var(--color-primary);
-    position: sticky;
-    bottom: 0;
-    z-index: var(--z-index-footer);
 }
 
 .konjunkturphase-comparison {

--- a/app/tests/Feature/Livewire/Views/KonjunkturphaseStartScreenTest.php
+++ b/app/tests/Feature/Livewire/Views/KonjunkturphaseStartScreenTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use Domain\Definitions\Card\Dto\ModifierParameters;
+use Domain\Definitions\Konjunkturphase\Dto\Zeitsteine;
+use Domain\Definitions\Konjunkturphase\Dto\ZeitsteinePerPlayer;
+use Domain\Definitions\Konjunkturphase\KonjunkturphaseDefinition;
+use Domain\Definitions\Konjunkturphase\ValueObject\KonjunkturphasenId;
+use Domain\Definitions\Konjunkturphase\ValueObject\KonjunkturphaseTypeEnum;
+
+it('renders the actions bar before the content so Weiter is visible without scrolling on small screens', function () {
+    $konjunkturphase = new KonjunkturphaseDefinition(
+        id: KonjunkturphasenId::create(1),
+        type: KonjunkturphaseTypeEnum::AUFSCHWUNG,
+        name: 'Test',
+        description: 'Test description',
+        additionalEvents: '',
+        zeitsteine: new Zeitsteine([new ZeitsteinePerPlayer(2, 6)]),
+        kompetenzbereiche: [],
+        modifierIds: [],
+        modifierParameters: new ModifierParameters(),
+        auswirkungen: [],
+    );
+
+    $html = view('livewire.screens.konjunkturphase-start', [
+        'konjunkturphase' => $konjunkturphase,
+        'previousKonjunkturphase' => null,
+        'currentPage' => 0,
+    ])->render();
+
+    $actionsPos = strpos($html, 'konjunkturphase-start__actions');
+    $contentPos = strpos($html, 'konjunkturphase-start__content');
+
+    expect($actionsPos)->not->toBeFalse()
+        ->and($contentPos)->not->toBeFalse()
+        ->and($actionsPos)->toBeLessThan($contentPos);
+});


### PR DESCRIPTION
On small screens, the heading of the Konjunkturphasen-Wechsel screen was cut off at the top and not reachable.
I have simplyfied the layout and moved the "weiter" button to the top so it is always reachable