### PR TITLE
fix: crypto icon alignment

### DIFF
--- a/app/resources/css/app/icons.css
+++ b/app/resources/css/app/icons.css
@@ -151,3 +151,9 @@
 .icon-krypto:before {
   content: "\e915";
 }
+
+/* Glyph sits high in its em square — nudge it down to align with surrounding text. */
+.icon-krypto {
+    position: relative;
+    top: 0.1em;
+}

--- a/app/resources/views/components/gameboard/cardPile/card.css
+++ b/app/resources/views/components/gameboard/cardPile/card.css
@@ -119,6 +119,12 @@
     i {
         font-size: 1.5rem;
     }
+
+    /* Grid centering already handles vertical alignment — reset the global
+       .icon-krypto glyph offset that would otherwise push the icon too low. */
+    .icon-krypto {
+        top: 0;
+    }
 }
 
 .card__actions-header {

--- a/app/resources/views/components/gameboard/investitionen/investitionen.css
+++ b/app/resources/views/components/gameboard/investitionen/investitionen.css
@@ -13,6 +13,12 @@
         i {
             font-size: 3rem;
         }
+
+        /* Flex centering already handles vertical alignment — reset the global
+           .icon-krypto glyph offset that would otherwise push the icon too low. */
+        .icon-krypto {
+            top: 0;
+        }
     }
 }
 


### PR DESCRIPTION
The icon was rendered a bit above the centerline -> manually correct