### PR TITLE
fix: rendering of error message in MoneySheet forms

### DIFF
--- a/app/resources/css/app/form.css
+++ b/app/resources/css/app/form.css
@@ -49,6 +49,12 @@ fieldset {
 
 .form-error {
     color: var(--color-error);
+
+    &.badge-with-background {
+        display: block;
+        height: auto;
+        padding-block: var(--spacing-100);
+    }
 }
 
 input {


### PR DESCRIPTION
The content was squashed in weird ways and the container did not scale properly.