### PR TITLE
fix: lebensziel selection no longer resets to empty

### DIFF
--- a/app/app/Livewire/Traits/HasPreGamePhase.php
+++ b/app/app/Livewire/Traits/HasPreGamePhase.php
@@ -81,7 +81,7 @@ trait HasPreGamePhase
 
     public function selectLebensZiel(int|string $lebensziel): void
     {
-        $this->lebenszielForm->lebensziel = is_int($lebensziel) ? $lebensziel : null;
+        $this->lebenszielForm->lebensziel = is_numeric($lebensziel) ? (int) $lebensziel : null;
     }
 
     public function startGame(): void

--- a/app/tests/Feature/Livewire/Views/PreGameTest.php
+++ b/app/tests/Feature/Livewire/Views/PreGameTest.php
@@ -33,16 +33,18 @@ beforeEach(function () {
 
 describe('selectLebensZiel', function () {
     test('selecting a valid lebensziel sets the form value', function () {
+        // The browser <select> always delivers its value as a string, e.g. "1".
         Livewire::test(GameUi::class, ['gameId' => $this->gameId, 'myself' => $this->p1])
-            ->call('selectLebensZiel', 1)
+            ->call('selectLebensZiel', '1')
             ->assertSet('lebenszielForm.lebensziel', 1);
     });
 
     test('re-selecting the placeholder option resets lebensziel to null', function () {
+        // The placeholder option's value is the empty string (see selectLebensziel.blade.php).
         Livewire::test(GameUi::class, ['gameId' => $this->gameId, 'myself' => $this->p1])
-            ->call('selectLebensZiel', 1)
+            ->call('selectLebensZiel', '1')
             ->assertSet('lebenszielForm.lebensziel', 1)
-            ->call('selectLebensZiel', '---')
+            ->call('selectLebensZiel', '')
             ->assertSet('lebenszielForm.lebensziel', null);
     });
 });


### PR DESCRIPTION
The is_int() guard rejected the string value a browser <select> sends, so every valid selection was reset to null. Use is_numeric() + cast.

Closes #675